### PR TITLE
spanner/dbapi/Connection: add update_ddl method

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -57,3 +57,18 @@ class Connection(object):
             session.create()
 
         return Cursor(session)
+
+
+    def update_ddl(self, ddl_statements):
+        """
+        Runs the list of Data Definition Language (DDL) statements on the specified
+        database. Note that each DDL statement MUST NOT contain a semicolon.
+
+        Args:
+            ddl_statements: a list of DDL statements, each without a semicolon.
+
+        Returns:
+            google.api_core.operation.Operation
+        """
+
+        return self.__dbhandle.update_ddl(ddl_statements)


### PR DESCRIPTION
Adds a method to Connection to allow it to
update the Data Definition Language e.g. to
create or update tables.

This method is necessary for flexibility when
creating and updating tables.