### PR TITLE
dbapi: implement expected PEP-0249 globals

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -19,6 +19,15 @@ from .exceptions import Error
 from .parse_utils import parse_spanner_url
 from .version import USER_AGENT
 
+### Globals that MUST be defined ###
+apilevel = "2.0"  # Implements the Python Database API specification 2.0 version.
+paramstyle = 'at-named'  # '@' is used by Cloud Spanner as the param style but
+                         # unfortunately that style isn't listed in any of the options 
+                         # https://www.python.org/dev/peps/pep-0249/#paramstyle
+                         # so we are going with a custom named paramstyle.
+threadsafety = 2  # Threads may share the module and connections but not cursors.
+
+
 def connect(spanner_url, credentials_uri=None):
     """Connects to Cloud Spanner.
 

--- a/tests/spanner/dbapi/test_globals.py
+++ b/tests/spanner/dbapi/test_globals.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from spanner.dbapi import (
+        apilevel,
+        paramstyle,
+        threadsafety
+)
+
+
+class DBAPIGlobalsTests(TestCase):
+    def test_apilevel(self):
+        self.assertEqual(apilevel, '2.0', 'We implement PEP-0249 version 2.0')
+        self.assertEqual(paramstyle, 'at-named', 'Cloud Spanner uses @param')
+        self.assertEqual(threadsafety, 2, 'The module and connections can be shared across threads but not cursors')


### PR DESCRIPTION
Implements the globals expected as per
https://www.python.org/dev/peps/pep-0249/#globals

* apilevel:     '2.0' (we are implement API version 2.0)
* paramstyle: 'at-named' since Cloud Spanner uses '@param'
              yet PEP-0249 doesn't provide such a name
* threadsafety: 2 (users can share the module and connections
                  but not cursors)

Updates #7