### PR TITLE
dbapi: detect and run DDL updates through Cursor.execute

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -56,7 +56,7 @@ class Connection(object):
         if not session.exists():
             session.create()
 
-        return Cursor(session)
+        return Cursor(session, self)
 
 
     def update_ddl(self, ddl_statements):

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -150,14 +150,20 @@ def validate_instance_config(instance_config):
     return None
 
 
+STMT_DDL = 'DDL'
 STMT_NON_UPDATING = 'NON_UPDATING'
 STMT_UPDATING = 'UPDATING'
 
 # Heuristic for identifying statements that don't need to be run as updates.
 re_NON_UPDATE = re.compile('^\s*(SELECT|ANALYZE|AUDIT|EXPLAIN|SHOW)', re.UNICODE|re.IGNORECASE)
 
-def classify_stmt(sql):
-    if re_NON_UPDATE.match(sql):
-        return STMT_NON_UPDATING
+# DDL statements follow https://cloud.google.com/spanner/docs/data-definition-language
+re_DDL = re.compile('^\s*(CREATE TABLE|CREATE DATABASE|ALTER TABLE|DROP TABLE|DROP INDEX)', re.UNICODE|re.IGNORECASE)
 
-    return STMT_UPDATING
+def classify_stmt(sql):
+    if re_DDL.match(sql):
+        return STMT_DDL
+    elif re_NON_UPDATE.match(sql):
+        return STMT_NON_UPDATING
+    else:
+        return STMT_UPDATING


### PR DESCRIPTION
Support DDL update statements in Cursor.execute.
We can now run

```python
    with conn.cursor() as cur:
        stmts = [
        """INSERT INTO AckWorthSingers (SingerId, FirstName, LastName) Values (10, 'Wiz', 'Khalifa')""",
        """DROP TABLE AckworthSingers""",
        """CREATE TABLE AckworthSingers (
                      SingerId   INT64 NOT NULL,
                      FirstName  STRING(1024),
                      LastName   STRING(1024),
                      BirthDate  DATE,
                    ) PRIMARY KEY(SingerId)""",
        """SELECT COUNT(*) FROM Singers""",
        ]

        for stmt in stmts:
              cur.execute(stmt)
```
without any problems and the changes will be reflected

Fixes #20