### PR TITLE
all, tox.ini: bring back flake8, isort linting

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -15,14 +15,19 @@
 from google.cloud import spanner_v1 as spanner
 
 from .connection import Connection
-
 # These need to be included in the top-level package for PEP-0249 DB API v2.
-from .exceptions import (  # noqa
-    Error, IntegrityError, OperationalError, ProgrammingError, Warning, InterfaceError,
-    DatabaseError, DataError, InternalError, NotSupportedError
+from .exceptions import (
+    DatabaseError, DataError, Error, IntegrityError, InterfaceError,
+    InternalError, NotSupportedError, OperationalError, ProgrammingError,
+    Warning,
 )
-
-from .parse_utils import parse_spanner_url, validate_instance_config
+from .parse_utils import (
+    extract_connection_params, parse_spanner_url, validate_instance_config,
+)
+from .types import (
+    BINARY, DATETIME, NUMBER, ROWID, STRING, Date, DateFromTicks, Time,
+    TimeFromTicks, Timestamp, TimestampFromTicks,
+)
 from .version import USER_AGENT
 
 # Globals that MUST be defined ###
@@ -110,3 +115,13 @@ def connect(spanner_url, credentials_uri=None):
         _ = lro
 
     return Connection(db)
+
+
+__all__ = [
+    'DatabaseError', 'DataError', 'Error', 'IntegrityError', 'InterfaceError',
+    'InternalError', 'NotSupportedError', 'OperationalError', 'ProgrammingError',
+    'Warning', 'USER_AGENT', 'apilevel', 'connect', 'paramstyle', 'threadsafety',
+    'extract_connection_params', 'parse_spanner_url',
+    'Date', 'DateFromTicks', 'Time', 'TimeFromTicks', 'Timestamp', 'TimestampFromTicks',
+    'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID',
+]

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -24,7 +24,7 @@ class ParseUtilsTests(TestCase):
             url = None
             got = parse_spanner_url(url)
             self.assertEqual(got, None)
-        self.assertEqual(*exc.exception.args, 'expecting a non-blank spanner_url')
+        self.assertEqual(exc.exception.args, ('expecting a non-blank spanner_url',))
 
     def test_no_host(self):
         # No host present in the URL.
@@ -32,7 +32,7 @@ class ParseUtilsTests(TestCase):
             url = '://spanner.googleapis.com/projects/test-project-012345/instances/test-instance/databases/dev-db'
             got = parse_spanner_url(url)
             self.assertEqual(got, None)
-        self.assertEqual(*exc.exception.args, 'expecting cloudspanner as the scheme')
+        self.assertEqual(exc.exception.args, ('expecting cloudspanner as the scheme',))
 
     def test_invalid_scheme(self):
         # Doesn't contain "cloudspanner" as the scheme.
@@ -40,7 +40,7 @@ class ParseUtilsTests(TestCase):
             url = 'foo://spanner.googleapis.com/projects/test-project-012345/instances/test-instance/databases/dev-db'
             got = parse_spanner_url(url)
             self.assertEqual(got, None)
-        self.assertEqual(*exc.exception.args, 'invalid scheme foo, expected cloudspanner')
+        self.assertEqual(exc.exception.args, ('invalid scheme foo, expected cloudspanner',))
 
     def test_with_host(self):
         url = (

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py3{7}-django{22}
+    flake8
 
 [testenv]
 setenv =
@@ -12,3 +13,12 @@ deps =
     six
 commands =
     python runtests.py
+
+[testenv:flake8]
+skip_install = True
+deps =
+    flake8
+    isort
+commands =
+    flake8
+    isort --recursive --check-only --diff


### PR DESCRIPTION
Bring back flake8 and isort into the tox.ini file,
and also address the post merge code-review comments
from https://github.com/orijtech/spanner-orm/pull/24#pullrequestreview-312927363
which:
* use __all__  to all the exports
* remove the use of the comment #noqa

Fixes #25