### PR TITLE
dbapi: update, document and test extract_connection_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,47 @@ description (Column(name='date', type_code=5), Column(name='isoyear', type_code=
 Time spent  1.6195518970489502
 ```
 
+### Django connection params
+
+Settings should be a dict containing either:
+
+a) 'SPANNER_URL' as the key and expecting a URL of the form:
+```
+cloudspanner:[//host[:port]]/project/<project_id>/instances/
+<instance-id>/databases/<database-name>?property-name=property-value
+```
+For example:
+```python
+DATABASE={
+    'default': {
+        "SPANNER_URL":  "cloudspanner:/projects/appdev/instances/dev1/databases/db1?"
+                        "instance_config=projects/appdev/instanceConfigs/regional-us-west2"
+    }
+}
+```
+
+b) Otherwise expects parameters whose keys are capitalized and
+are of the form:
+```python
+{
+    "NAME":             "<database_name>",
+    "INSTANCE":         "<instance_name>",
+    "AUTOCOMMIT":       True or False,
+    "READONLY":         True or False,
+    "PROJECT_ID":       "<project_id>",
+    "INSTANCE_CONFIG":  "[instance configuration if using a brand new database]",
+}
+```
+
+for example:
+
+```python
+{
+    "NAME":             "db1",
+    "INSTANCE":         "dev1",
+    "AUTOCOMMIT":       True,
+    "READONLY":         False,
+    "PROJECT_ID":       "appdev",
+    "INSTANCE_CONFIG":  "projects/appdev/instanceConfigs/regional-us-west2",
+}
+```


### PR DESCRIPTION
* Update README.md as well as the Python docs for
`extract_connection_params` showing the format as
well as examples
* Added tests for each code path as well as parity
tests for `SPANNER_URL` vs dict key=value pairs

Fixes #27