### PR TITLE
dbapi: implement Cursor.fetchmany

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -152,6 +152,28 @@ class Cursor(object):
     def fetchall(self):
         return list(self.__iter__())
 
+    def fetchmany(self, n=50):
+        """
+        Fetch the next set of rows of a query result, returning a sequence of sequences.
+        An empty sequence is returned when no more rows are available.
+
+        Args:
+            n: optional integer to determine the maximum number of results to fetch.
+            
+
+        Raises:
+            Error if the previous call to .execute*() did not produce any result set
+            or if no call was issued yet.
+        """
+        items = []
+        for i in range(n):
+            try:
+                items.append(self.__next__())
+            except StopIteration:
+                break
+
+        return items
+
     @property
     def arraysize(self):
         raise ProgrammingError('Unimplemented')


### PR DESCRIPTION
Running this program
```python
def main():
    conn = connect(instance_url)
    t1 = time.time()
    with conn.cursor() as cur:
        stmts = [
        """
        SELECT * from AckWorthSingers
        """,
        ]
        for stmt in stmts:
            print('**** SQL ****\n', stmt, '\n')
            cur.execute(stmt)
            rows = cur.fetchmany(100)
            for i, row in enumerate(rows):
                print(i, row)

    t2 = time.time()
    print('Time spent ', t2-t1)
```

produces

```shell
**** SQL ****

        SELECT * from AckWorthSingers

0 [1, 'John', 'Wick', None]
1 [2, 'John', 'Wick', None]
2 [3, 'qohn', 'Wick', None]
3 [4, 'nohn', 'Wick', None]
4 [5, 'xohn', 'Wick', None]
5 [6, 'yohn', 'Wick', None]
6 [7, 'mohn', 'Wick', None]
7 [8, 'nohn', 'Wick', None]
8 [9, 'lohn', 'Wick', None]
9 [10, 'John', 'Wick', None]
10 [11, 'John', 'Wick', None]
11 [12, 'John', 'Wick', None]
12 [13, 'John', 'Wick', None]
13 [14, 'John', 'Wick', None]
14 [15, 'John', 'Wick', None]
15 [16, 'John', 'Wick', None]
16 [17, 'Xohn', 'Wick', None]
17 [18, 'Pohn', 'Wick', None]
18 [20, 'Kohn', 'Wick', None]
19 [21, 'Pohn', 'Wick', None]
20 [22, 'Xohn', 'Wick', None]
Time spent  0.8858218193054199
```

Fixes #31