### PR TITLE
dbapi: add param_types={} to Cursor.execute innards

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -76,10 +76,29 @@ class Cursor(object):
                 self.__do_update_ddl(sql)
 
             elif classify_stmt(sql) == STMT_NON_UPDATING:
-                self.__do_execute_non_update(sql, args or None)
+                self.__do_execute_non_update(
+                    sql, args or None,
+                    # param_types aren't actually required but an empty dict must be passed
+                    # to avoid
+                    #   "ValueError("Specify 'param_types' when passing 'params'.").
+                    # See https://github.com/orijtech/spanner-orm/issues/35
+                    # Instead of examining every parameter and making
+                    # a corresponding protobuf cast, we can just pass
+                    # in param_types={}
+                    param_types={})
 
             else:
-                self.__session.run_in_transaction(self.__do_execute_update, sql, args or None)
+                self.__session.run_in_transaction(
+                    self.__do_execute_update,
+                    sql, args or None,
+                    # param_types aren't actually required but an empty dict must be
+                    # passed to avoid
+                    #   "ValueError("Specify 'param_types' when passing 'params'.").
+                    # See https://github.com/orijtech/spanner-orm/issues/35
+                    # Instead of examining every parameter and making
+                    # a corresponding protobuf cast, we can just pass
+                    # in param_types={}
+                    param_types={})
 
         except grpc_exceptions.AlreadyExists as e:
             raise IntegrityError(e.details if hasattr(e, 'details') else e)


### PR DESCRIPTION
Python Spanner client methods seem to require a

  param_types (dict)

when passing in parameters but really that's because
Cloud Spanner recommends passing in @typed_parameters
as per
    https://cloud.google.com/spanner/docs/lexical#query-parameters

Thus, instead of:

```python
    with conn.cursor() as cur:
        cur.execute('SELECT * from AckWorthSingers WHERE SingerId!=?', 10)
        cur.execute(stmt)
        rows = cur.fetchmany(100)
        for i, row in enumerate(rows):
            print(i, row)
```

it should be:

```python
    with conn.cursor() as cur:
        cur.execute('SELECT * from AckWorthSingers WHERE SingerId!=@singerId', dict(singerId=10))
        rows = cur.fetchmany(100)
        for i, row in enumerate(rows):
            print(i, row)
```

of which the difference is in

a) The Query parameters @singerId instead of ?
        'WHERE SingerId!=@singerId'

and the parameters passed in are

        dict(singerId=10)

Fixes #35