### PR TITLE
dbapi/Cursor: detect and raise an error for unsupported SQL

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -15,9 +15,9 @@
 import google.api_core.exceptions as grpc_exceptions
 
 from .exceptions import (
-    Error, IntegrityError, OperationalError, ProgrammingError,
+    Error, IntegrityError, NotSupportedError, OperationalError, ProgrammingError,
 )
-from .parse_utils import STMT_DDL, STMT_NON_UPDATING, classify_stmt
+from .parse_utils import STMT_DDL, STMT_NON_UPDATING, classify_stmt, unsupported_sql
 
 _UNSET_COUNT = -1
 
@@ -66,6 +66,9 @@ class Cursor(object):
         """
         if not self.__session:
             raise ProgrammingError('Cursor is not connected to the database')
+
+        if unsupported_sql(sql):
+            raise NotSupportedError('`%s` is unsupported SQL by Cloud Spanner' % sql)
 
         # Classify whether this is a read-only SQL statement.
         try:

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -231,3 +231,29 @@ def classify_stmt(sql):
         return STMT_NON_UPDATING
     else:
         return STMT_UPDATING
+
+
+re_UNSUPPORTED_SQL = [
+        #   ALTER TABLE <TABLE_NAME> ADD CONSTRAINT <constraint_name> UNIQUE (columns)
+        # See Issue https://github.com/orijtech/spanner-orm/issues/37.
+        re.compile(r'ALTER.+ADD CONSTRAINT.+UNIQUE', re.UNICODE | re.IGNORECASE | re.DOTALL),
+        # TODO: Add other unsupported SQL patterns here.
+]
+
+
+def unsupported_sql(sql):
+    """
+    Report whether SQL statements have no equivalent in Google SQL
+    and are thus not supported by Cloud Spanner.
+
+    Args:
+        sql: a SQL statement string.
+
+    Returns:
+        True if the SQL is NOT supported by Cloud Spanner, otherwise False.
+    """
+    for regex in re_UNSUPPORTED_SQL:
+        if regex.match(sql):
+            return True
+
+    return False


### PR DESCRIPTION
Cloud Spanner doesn't currently support statements
such as

    ALTER TABLE t ADD CONSTRAINT t_al_m UNIQUE (al, m)

This change adds a pass that if given known unsupported
SQL patterns, will return True or False.

This change will currently raise an Exception but that'll
be dealt with in a follow-up change on whether to log it
to the caller or transform it entirely.

Fixes #37