### PR TITLE
dbapi: remove Cursor.execute() exception hiding

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -14,9 +14,7 @@
 
 import google.api_core.exceptions as grpc_exceptions
 
-from .exceptions import (
-    Error, IntegrityError, OperationalError, ProgrammingError,
-)
+from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import STMT_DDL, STMT_NON_UPDATING, classify_stmt
 
 _UNSET_COUNT = -1
@@ -108,9 +106,6 @@ class Cursor(object):
 
         except grpc_exceptions.InternalServerError as e:
             raise OperationalError(e.details if hasattr(e, 'details') else e)
-
-        except Exception as e:  # Catch all other exceptions and re-raise them.
-            raise Error(e.details if hasattr(e, 'details') else e)
 
     def __do_execute_update(self, transaction, sql, *args, **kwargs):
         res = transaction.execute_update(sql, *args, **kwargs)


### PR DESCRIPTION
This code hides the location of the exception which makes debugging more difficult. I've found myself commenting it out more than once.

e.g. (unhelpful)
```
...
  File "/home/tim/code/spanner-orm/spanner/dbapi/cursor.py", line 113, in execute
    raise Error(e.details if hasattr(e, 'details') else e)
django.db.utils.Error: Specify 'params' when passing 'param_types'.
```
instead of:
```
...
  File "/home/tim/code/django/django/db/backends/utils.py", line 100, in execute
    return super().execute(sql, params)
  File "/home/tim/code/django/django/db/backends/utils.py", line 68, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/tim/code/django/django/db/backends/utils.py", line 77, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/tim/code/django/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/home/tim/code/spanner-orm/spanner/dbapi/cursor.py", line 101, in execute
    param_types={})
  File "/home/tim/.virtualenvs/django37/lib/python3.7/site-packages/google/cloud/spanner_v1/session.py", line 299, in run_in_transaction
    return_value = func(txn, *args, **kw)
  File "/home/tim/code/spanner-orm/spanner/dbapi/cursor.py", line 113, in __do_execute_update
    res = transaction.execute_update(sql, *args, **kwargs)
  File "/home/tim/.virtualenvs/django37/lib/python3.7/site-packages/google/cloud/spanner_v1/transaction.py", line 188, in execute_update
    params_pb = self._make_params_pb(params, param_types)
  File "/home/tim/.virtualenvs/django37/lib/python3.7/site-packages/google/cloud/spanner_v1/transaction.py", line 161, in _make_params_pb
    raise ValueError("Specify 'params' when passing 'param_types'.")
ValueError: Specify 'params' when passing 'param_types'.
```