### PR TITLE
dbapi: classify every CREATE as updating DDL

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -71,12 +71,13 @@ class Cursor(object):
         param_types = {} if args else None
         # Classify whether this is a read-only SQL statement.
         try:
-            if classify_stmt(sql) == STMT_DDL:
+            classification = classify_stmt(sql)
+            if classification == STMT_DDL:
                 # Special case: since Spanner.Session won't execute DDL updates
                 # by invoking `execute_sql` or `execute_update`, we must run
                 # DDL updates on the database handle itself.
                 self.__do_update_ddl(sql)
-            elif classify_stmt(sql) == STMT_NON_UPDATING:
+            elif classification == STMT_NON_UPDATING:
                 self.__do_execute_non_update(
                     sql, args or None,
                     param_types=param_types,

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -219,8 +219,8 @@ re_NON_UPDATE = re.compile(r'^\s*(SELECT|ANALYZE|AUDIT|EXPLAIN|SHOW)', re.UNICOD
 
 # DDL statements follow https://cloud.google.com/spanner/docs/data-definition-language
 re_DDL = re.compile(
-    r'^\s*(CREATE TABLE|CREATE DATABASE|ALTER TABLE|DROP TABLE|DROP INDEX)',
-    re.UNICODE | re.IGNORECASE
+    r'^\s*(CREATE|ALTER|DROP)',
+    re.UNICODE | re.IGNORECASE | re.DOTALL,
 )
 
 


### PR DESCRIPTION
Previously, when running

    python3 manage.py migrate

We'd get

        raise ProgrammingError(e.details if hasattr(e, 'details') else e)
        django.db.utils.ProgrammingError: 400 Statement not supported:
        CreateIndexStatement [at 1:1]\nCREATE UNIQUE INDEX
        django_content_type_app_label_model_76bd3d3b_uniq ON djan...\n^

but the error resulted from

        CREATE UNIQUE INDEX

not being recognized as a DDL update.

Every CREATE statement is a DDL update, so this change recognizes
every `CREATE|DROP|ALTER` as DDL statements, which they are.