### PR TITLE
dbapi,django: generate missing ids + fix SQL alter statements

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -40,10 +40,12 @@ class Connection(object):
         return self.close()
 
     def commit(self):
-        raise Error('unimplemented')
+        # We don't manage transactions.
+        pass
 
     def rollback(self):
-        raise Error('unimplemented')
+        # We don't manage transactions.
+        pass
 
     def cursor(self):
         session = self.__dbhandle.session()

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import re
 from urllib.parse import urlparse
 
@@ -259,3 +260,23 @@ def parse_insert(insert_sql):
         }
     else:
         return None
+
+
+def add_missing_id(columns, params, gen_id):
+    if 'id' in columns:
+        return (columns, params,)
+
+    # It is imperative that we copy and NOT mutate our original arguments as
+    # references to them might be used elsewhere.
+    new_columns = copy.deepcopy(columns)
+    new_params = copy.deepcopy(params)
+
+    # Otherwise auto insert 'id'.
+    new_columns += type(columns)(['id'])
+
+    # param is an iterable of iterables e.g. list of list.
+    for i, new_param in enumerate(new_params):
+        new_param += type(new_param)([gen_id()])
+        new_params[i] = new_param
+
+    return (new_columns, new_params,)

--- a/spanner/django/schema.py
+++ b/spanner/django/schema.py
@@ -5,6 +5,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_table = "CREATE TABLE %(table)s (%(definition)s) PRIMARY KEY(%(primary_key)s)"
     sql_create_unique = "CREATE UNIQUE INDEX %(name)s ON %(table)s (%(columns)s)"
 
+    # Cloud Spanner requires when changing if a column is NULLABLE,
+    # that it should get redefined with its type and size.
+    # See https://cloud.google.com/spanner/docs/schema-updates#updates-that-require-validation
+    sql_alter_column_null = "ALTER COLUMN %(column)s %(type)s"
+    sql_alter_column_not_null = "ALTER COLUMN %(column)s %(type)s NOT NULL"
+    sql_alter_column_type = "ALTER COLUMN %(column)s %(type)s"
+
+    sql_delete_column = "ALTER TABLE %(table)s DROP COLUMN %(column)s"
+
     def create_model(self, model):
         """
         Create a table and any accompanying indexes or unique constraints for


### PR DESCRIPTION
* Generates the missing id field for columns and generates
corresponding uuid4() for the params/values, and this is an
alright fix because currently the only user of dbapi is
spanner/django, which can generate AutoFields with `primary_key=True`
which assumes that the Database will generate ids automatically.

Therefore, given:

    Columns: ['app', 'name']
    Params:  [('ap', 'n',), ('bp', 'm',)]

It'll get fixed up to

    Columns: ['app', 'name']
    Params:  [
        ('ap', 'n', '8a17c112-fbd1-4c03-90f3-df8212c17f47',),
        ('bp', 'm', '7340b5e1-97f6-44ba-985f-e2d98f32c81e',),
    ]

* Adds the appropriate sql_alter* statements to
spanner/djang/schema.DatabaseWrapper to match Spanner's SQL

* Makes noops for lastrowid, commit, rollback since Spanner
doesn't return the lastrowid and the DBAPI v2 instructs us to
return None if the DB doesn't support lastrowid. commit and rollback
are now just `pass` because the underlying implementation uses
transactions under the hood

Updates #46
Fixes #50