### PR TITLE
dbapi: translate pyformat args to spanner args

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -19,7 +19,7 @@ import google.api_core.exceptions as grpc_exceptions
 from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
     STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, add_missing_id, classify_stmt,
-    parse_insert,
+    parse_insert, sql_pyformat_args_to_spanner,
 )
 
 _UNSET_COUNT = -1
@@ -142,10 +142,11 @@ class Cursor(object):
     def gen_uuid4(self):
         return str(uuid4())
 
-    def __do_execute_non_update(self, sql, *args, **kwargs):
+    def __do_execute_non_update(self, sql, params, **kwargs):
         # Reference
         #  https://googleapis.dev/python/spanner/latest/session-api.html#google.cloud.spanner_v1.session.Session.execute_sql
-        res = self.__session.execute_sql(sql, *args, **kwargs)
+        sql, params = sql_pyformat_args_to_spanner(sql, params)
+        res = self.__session.execute_sql(sql, params=params, **kwargs)
         if type(res) == int:
             self.__row_count = res
             self.__itr = None


### PR DESCRIPTION
Implemented utilities to detect and translate
pyformat parameters into @ named parameters that
Spanner understand so

        SQL: SELECT
                table_name
            FROM
                information_schema.tables
            WHERE
                table_catalog = '' and table_schema = %s
        Params: ('',)

becomes:

        SQL: SELECT
                table_name
            FROM
                information_schema.tables
            WHERE
                table_catalog = '' and table_schema = @a0
        Params: {'a0': ''}

which now correctly will print

    python3 conn.py
    0 ['auth_group']
    1 ['auth_group_permissions']
    2 ['auth_permission']
    3 ['auth_user']
    4 ['auth_user_groups']
    5 ['auth_user_user_permissions']
    6 ['django_admin_log']
    7 ['django_content_type']
    8 ['django_migrations']
    9 ['django_session']
    Time spent  0.7119221687316895

and the same thing happens for arguments that are passed in as

    %(field)s

which will be adequately translated to named parameters.

Fixes #52