### PR TITLE
django: implement bulk_insert_sql

### DIFF
--- a/spanner/django/operations.py
+++ b/spanner/django/operations.py
@@ -4,3 +4,8 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 class DatabaseOperations(BaseDatabaseOperations):
     def quote_name(self, name):
         return name
+
+    def bulk_insert_sql(self, fields, placeholder_rows):
+        placeholder_rows_sql = (", ".join(row) for row in placeholder_rows)
+        values_sql = ", ".join("(%s)" % sql for sql in placeholder_rows_sql)
+        return "VALUES " + values_sql


### PR DESCRIPTION
Implements the standard bulk_insert_sql method as
MySQL's Django backend does.

Fixes #54