### PR TITLE
dbapi: make AutoField INT64 and generate rand_int64

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -22,7 +22,8 @@ from .exceptions import (
     Warning,
 )
 from .parse_utils import (
-    extract_connection_params, parse_spanner_url, validate_instance_config,
+    extract_connection_params, gen_rand_int64, parse_spanner_url,
+    validate_instance_config,
 )
 from .types import (
     BINARY, DATETIME, NUMBER, ROWID, STRING, Date, DateFromTicks, Time,
@@ -121,7 +122,7 @@ __all__ = [
     'DatabaseError', 'DataError', 'Error', 'IntegrityError', 'InterfaceError',
     'InternalError', 'NotSupportedError', 'OperationalError', 'ProgrammingError',
     'Warning', 'USER_AGENT', 'apilevel', 'connect', 'paramstyle', 'threadsafety',
-    'extract_connection_params', 'parse_spanner_url',
+    'extract_connection_params', 'parse_spanner_url', 'gen_rand_int64',
     'Date', 'DateFromTicks', 'Time', 'TimeFromTicks', 'Timestamp', 'TimestampFromTicks',
     'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID',
 ]

--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from uuid import uuid4
-
 import google.api_core.exceptions as grpc_exceptions
 
 from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
     STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, add_missing_id, classify_stmt,
-    parse_insert, sql_pyformat_args_to_spanner,
+    gen_rand_int64, parse_insert, sql_pyformat_args_to_spanner,
 )
 
 _UNSET_COUNT = -1
@@ -129,7 +127,7 @@ class Cursor(object):
         if params:
             # Case c)
             parts = parse_insert(sql)
-            columns, params = add_missing_id(parts.get('columns'), params, self.gen_uuid4)
+            columns, params = add_missing_id(parts.get('columns'), params, gen_rand_int64)
             return transaction.insert_or_update(
                 table=parts.get('table'),
                 columns=columns,
@@ -138,9 +136,6 @@ class Cursor(object):
         else:
             # Either of cases a) or b)
             return transaction.execute_update(sql)
-
-    def gen_uuid4(self):
-        return str(uuid4())
 
     def __do_execute_non_update(self, sql, params, **kwargs):
         # Reference

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -15,6 +15,7 @@
 import copy
 import re
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from .exceptions import Error
 
@@ -334,3 +335,8 @@ def sql_pyformat_args_to_spanner(sql, params):
             named_args[key] = params[i]
 
     return sql, named_args
+
+
+def gen_rand_int64():
+    # Credit to https://stackoverflow.com/a/3530326.
+    return uuid4().int & 0x7FFFFFFFFFFFFFFF

--- a/spanner/django/base.py
+++ b/spanner/django/base.py
@@ -30,8 +30,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     # Mapping of Field objects to their column types.
     # TODO: audit max lengths of all STRING fields.
     data_types = dict(
-            AutoField='STRING(64)',  # Possibly using a UUID in place of AutoField.
-            BigAutoField='UUID',
+            AutoField='INT64',
+            BigAutoField='INT64',
             BinaryField='BYTES',
             BooleanField='BOOL',
             CharField='STRING(%(max_length)s)',


### PR DESCRIPTION
Taking Tim's clever observation, we could still use
INT64 and generate random int64s from UUID4s by
getting the high signed 64 bits of uuuid4().int.

Updates #46
Fixes #48
Updates #47