### PR TITLE
dbapi: parse out VALUES format specifiers in groups

### DIFF
--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -193,6 +193,7 @@ class ParseUtilsTests(TestCase):
                 {
                     'table': 'django_migrations',
                     'columns': ['app', 'name', 'applied'],
+                    'values_pyformat': ['(%s, %s, %s)'],
                 },
             ),
             (
@@ -202,6 +203,15 @@ class ParseUtilsTests(TestCase):
                 {
                     'table': 'sales.addresses',
                     'columns': ['street', 'city', 'state', 'zip_code'],
+                },
+            ),
+            (
+
+                'INSERT INTO auth_permission (name, content_type_id, codename) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,      %s, %s)',
+                {
+                    'table': 'auth_permission',
+                    'columns': ['name', 'content_type_id', 'codename'],
+                    'values_pyformat': ['(%s, %s, %s)', '(%s, %s, %s)', '(%s, %s, %s)', '(%s,      %s, %s)'],
                 },
             ),
         ]


### PR DESCRIPTION
Adds the ability for parse_insert to parse out
pyformat_value_placeholders, and send them back to the
caller with field 'values_pyformat', for example:

    INSERT INTO auth_permission (name, content_type_id, codename)
    VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,      %s, %s)

produces:

    {
        'table': 'auth_permission',
        'columns': ['name', 'content_type_id', 'codename'],
        'values_pyformat': [
            '(%s, %s, %s)', '(%s, %s, %s)',
            '(%s, %s, %s)', '(%s,      %s, %s)',
        ],
    }

Updates #60