### PR TITLE
dbapi: recognize missing pyformat args in add_missing_id

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -89,11 +89,7 @@ class Cursor(object):
                 self.__session.run_in_transaction(
                     self.__do_execute_insert,
                     sql,
-                    # Insert statements' params are only passed as tuples or lists,
-                    # yet for do_execute_update, we've got to pass in list of list.
-                    # https://googleapis.dev/python/spanner/latest/transaction-api.html\
-                    #           #google.cloud.spanner_v1.transaction.Transaction.insert
-                    [args] if args else None,
+                    args if args else None,
                 )
             else:
                 self.__session.run_in_transaction(
@@ -127,7 +123,11 @@ class Cursor(object):
         if params:
             # Case c)
             parts = parse_insert(sql)
-            columns, params = add_missing_id(parts.get('columns'), params, gen_rand_int64)
+            columns, params = add_missing_id(parts.get('columns'), params,
+                                             gen_rand_int64,
+                                             parts.get('values_pyformat'),
+                                             )
+
             return transaction.insert_or_update(
                 table=parts.get('table'),
                 columns=columns,

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -207,7 +207,8 @@ class ParseUtilsTests(TestCase):
             ),
             (
 
-                'INSERT INTO auth_permission (name, content_type_id, codename) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,      %s, %s)',
+                'INSERT INTO auth_permission (name, content_type_id, codename) '
+                'VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,      %s, %s)',
                 {
                     'table': 'auth_permission',
                     'columns': ['name', 'content_type_id', 'codename'],
@@ -236,6 +237,7 @@ class ParseUtilsTests(TestCase):
             (
                 ['id', 'app', 'name'],
                 [(5, 'ap', 'n',), (6, 'bp', 'm',)],
+                None,
                 (
                     ['id', 'app', 'name'],
                     [(5, 'ap', 'n',), (6, 'bp', 'm',)],
@@ -244,16 +246,48 @@ class ParseUtilsTests(TestCase):
             (
                 ['app', 'name'],
                 [('ap', 'n',), ('bp', 'm',)],
+                None,
                 (
                     ['app', 'name', 'id'],
                     [('ap', 'n', 1,), ('bp', 'm', 2,)]
                 ),
             ),
+            (
+                ['app', 'name', 'fn'],
+                ['ap', 'n', 'f1', 'bp', 'm', 'f2', 'cp', 'o', 'f3'],
+                ['(%s, %s, %s)', '(%s, %s, %s)', '(%s, %s, %s)'],
+                (
+                    ['app', 'name', 'fn', 'id'],
+                    [('ap', 'n', 'f1', 3,), ('bp', 'm', 'f2', 4,), ('cp', 'o', 'f3', 5,)]
+                ),
+            ),
+            (
+                ['app', 'name', 'fn', 'ln'],
+                [('ap', 'n', (45, 'nested',), 'll',), ('bp', 'm', 'f2', 'mt',), ('fp', 'cp', 'o', 'f3',)],
+                None,
+                (
+                    ['app', 'name', 'fn', 'ln', 'id'],
+                    [
+                        ('ap', 'n', (45, 'nested',), 'll', 6,),
+                        ('bp', 'm', 'f2', 'mt', 7,),
+                        ('fp', 'cp', 'o', 'f3', 8,),
+                    ],
+                ),
+            ),
+            (
+                ['app', 'name', 'fn'],
+                ['ap', 'n', 'f1'],
+                None,
+                (
+                    ['app', 'name', 'fn', 'id'],
+                    [('ap', 'n', 'f1', 9,)]
+                ),
+            ),
         ]
-        for i, case in enumerate(cases):
-            columns, params, want = case
+
+        for i, (columns, params, pyformat_args, want) in enumerate(cases):
             with self.subTest(i=i):
-                got = add_missing_id(columns, params, next_id)
+                got = add_missing_id(columns, params, next_id, pyformat_args)
                 self.assertEqual(got, want)
 
     def test_sql_pyformat_args_to_spanner(self):


### PR DESCRIPTION
Recognize missing pyformat args when given a statement
with VALUES and repeated pyformat args so

    VALUES (%s, ....%s), (%s, ....%s)...

for example:

    SQL: INSERT INTO auth_permission (name, content_type_id, codename)
         VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s)

    Params: (
        'Can add log entry', 295972172937908268, 'add_logentry',
        'Can change log entry', 295972172937908268, 'change_logentry',
        'Can delete log entry', 295972172937908268, 'delete_logentry',
        'Can view log entry', 295972172937908268, 'view_logentry',
    )

which we now correctly translate to:

    {
        'table': 'auth_permission',
        'columns': ['name', 'content_type_id', 'codename', 'id'],
        'params': [
            ('Can add log entry', 295972172937908268, 'add_logentry', id1),
            ('Can change log entry', 295972172937908268, 'change_logentry', id2),
            ('Can delete log entry', 295972172937908268, 'delete_logentry', id3),
            ('Can view log entry', 295972172937908268, 'view_logentry', id4),
        ]

Fixes #60