### PR TITLE
dbapi: bring back proper rows extraction from params

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -17,7 +17,7 @@ import google.api_core.exceptions as grpc_exceptions
 from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
     STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, classify_stmt, parse_insert,
-    sql_pyformat_args_to_spanner,
+    rows_for_insert_or_update, sql_pyformat_args_to_spanner,
 )
 
 _UNSET_COUNT = -1
@@ -124,10 +124,12 @@ class Cursor(object):
         if params:
             # Case c)
             parts = parse_insert(sql)
+            columns = parts.get('columns')
+            rows = rows_for_insert_or_update(columns, params, parts.get('values_pyformat'))
             return transaction.insert_or_update(
                 table=parts.get('table'),
-                columns=parts.get('columns'),
-                values=[params],
+                columns=columns,
+                values=rows,
             )
         else:
             # Either of cases a) or b)

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -274,6 +274,74 @@ def parse_insert(insert_sql):
     return parsed
 
 
+def rows_for_insert_or_update(columns, params, pyformat_args=None):
+    """
+    Create a tupled list of params to be used as a single value per
+    value that inserted from a statement such as
+        SQL:        'INSERT INTO t (f1, f2, f3) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s)'
+        Params A:   [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+        Params B:   [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    We'll have to convert both params types into:
+        Params: [(1, 2, 3,), (4, 5, 6,), (7, 8, 9,)]
+    """
+
+    if not pyformat_args:
+        # This is the case where we have for example:
+        # SQL:        'INSERT INTO t (f1, f2, f3)'
+        # Params A:   [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+        # Params B:   [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        #
+        # We'll have to convert both params types into:
+        #           [(1, 2, 3,), (4, 5, 6,), (7, 8, 9,)]
+        contains_all_list_or_tuples = True
+        for param in params:
+            if not (isinstance(param, list) or isinstance(param, tuple)):
+                contains_all_list_or_tuples = False
+                break
+
+        if contains_all_list_or_tuples:
+            # The case with Params A: [(1, 2, 3), (4, 5, 6)]
+            # Ensure that each param's length == len(columns)
+            columns_len = len(columns)
+            for param in params:
+                if columns_len != len(param):
+                    raise Error('\nlen(`%s`)=%d\n!=\ncolum_len(`%s`)=%d' % (
+                        param, len(param), columns, columns_len))
+            return params
+        else:
+            # The case with Params B: [1, 2, 3]
+            # Insert statements' params are only passed as tuples or lists,
+            # yet for do_execute_update, we've got to pass in list of list.
+            # https://googleapis.dev/python/spanner/latest/transaction-api.html\
+            #           #google.cloud.spanner_v1.transaction.Transaction.insert
+            n_stride = len(columns)
+    else:
+        # This is the case where we have for example:
+        # SQL:      'INSERT INTO t (f1, f2, f3) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s)'
+        # Params:   [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        #    which should become
+        # Columns:      (f1, f2, f3)
+        # new_params:   [(1, 2, 3,), (4, 5, 6,), (7, 8, 9,)]
+
+        # Sanity check: all the pyformat_values should have the exact same length.
+        first, rest = pyformat_args[0], pyformat_args[1:]
+        n_stride = first.count('%s')
+        for pyfmt_value in rest:
+            n = pyfmt_value.count('%s')
+            if n_stride != n:
+                raise Error('\nlen(`%s`)=%d\n!=\nlen(`%s`)=%d' % (
+                    first, n_stride, pyfmt_value, n))
+
+    # Now chop up the strides.
+    strides = []
+    for step in range(0, len(params), n_stride):
+        stride = tuple(params[step:step+n_stride:])
+        strides.append(stride)
+
+    return strides
+
+
 re_PYFORMAT = re.compile(r'(%s|%\([^\(\)]+\)s)+', re.DOTALL)
 
 


### PR DESCRIPTION
Row extraction from params is necessary so that
insert_or_update can be invoked.

We get calls with variants such as:

    INSERT INTO t(f1, f2) VALUES (%s, %s), (%s, %s)
    INSERT INTO t(f1, f2) VALUES
    INSERT INTO t(f1, f2)

with params of the variants:

    [1, 2, 3, 4]
    [(1, 2,), (3, 4,)]

and insert_or_update expects that those arguments be in
the final form:

    [(1, 2,), (3, 4,)]

We removed `add_missing_id` in PR #69, but expedited landing
that PR. This change is a modification/follow-up to that PR,
bringing back most parts of `add_missing_id` but this time
as a specialized function that handles row extraction.

Updates #69