### PR TITLE
dbapi: synchronously wait on long running operations to complete

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -105,14 +105,16 @@ def connect(spanner_url, credentials_uri=None):
 
         instance.configuration_name = instance_config
         lro = instance.create()
+        # Synchronously wait on the operation's completion.
         # TODO: Report the long-running operation result.
-        _ = lro
+        _ = lro.result()
 
     db = instance.database(db_name)
     if not db.exists():
         lro = db.create()
+        # Synchronously wait on the operation's completion.
         # TODO: Report the long-running operation result.
-        _ = lro
+        _ = lro.result()
 
     return Connection(db)
 

--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -64,4 +64,6 @@ class Connection(object):
         Returns:
             google.api_core.operation.Operation
         """
-        return self.__dbhandle.update_ddl(ddl_statements)
+        lro = self.__dbhandle.update_ddl(ddl_statements)
+        # Synchronously wait on the operation's completion.
+        return lro.result()


### PR DESCRIPTION
Invoke .result() on long running operations to
synchronously wait on their results to completion.

Fixes #74