### PR TITLE
all: handle timezones in datetime strings for datetime.strptime

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -22,7 +22,8 @@ from .exceptions import (
     Warning,
 )
 from .parse_utils import (
-    extract_connection_params, parse_spanner_url, validate_instance_config,
+    extract_connection_params, parse_datetimefield_value, parse_spanner_url,
+    validate_instance_config,
 )
 from .types import (
     BINARY, DATETIME, NUMBER, ROWID, STRING, Date, DateFromTicks, Time,
@@ -125,5 +126,5 @@ __all__ = [
     'Warning', 'USER_AGENT', 'apilevel', 'connect', 'paramstyle', 'threadsafety',
     'extract_connection_params', 'parse_spanner_url',
     'Date', 'DateFromTicks', 'Time', 'TimeFromTicks', 'Timestamp', 'TimestampFromTicks',
-    'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID',
+    'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID', 'parse_datetimefield_value',
 ]

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from datetime import datetime
 from urllib.parse import urlparse
 
 from .exceptions import Error
@@ -399,3 +400,20 @@ def sql_pyformat_args_to_spanner(sql, params):
             named_args[key] = params[i]
 
     return sql, named_args
+
+
+def parse_datetimefield_value(value):
+    if value is None:
+        return value
+
+    fmt, no_us_fmt = '%Y-%m-%d %H:%M:%S.%f', '%Y-%m-%d %H:%M:%S'
+    if value.count('+') > 0:
+        # Contains the timezone e.g.
+        #       2019-11-26 02:55:41.298430+00:00
+        fmt, no_us_fmt = '%Y-%m-%d %H:%M:%S.%f%z', '%Y-%m-%d %H:%M:%S%z'
+
+    try:
+        value = datetime.strptime(value, fmt)
+    except ValueError:  # time data does not match format (no microsecond?)
+        value = datetime.strptime(value, no_us_fmt)
+    return value

--- a/spanner/django/operations.py
+++ b/spanner/django/operations.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-
+import spanner.dbapi as Database
 from django.db.backends.base.operations import BaseDatabaseOperations
 
 
@@ -36,9 +35,4 @@ class DatabaseOperations(BaseDatabaseOperations):
         return converters
 
     def convert_datetimefield_value(self, value, expression, connection):
-        if value is not None:
-            try:
-                value = datetime.strptime(value, '%Y-%m-%d %H:%M:%S.%f')
-            except ValueError:  # time data does not match format (no microsecond?)
-                value = datetime.strptime(value, '%Y-%m-%d %H:%M:%S')
-        return value
+        return Database.parse_datetimefield_value(value)


### PR DESCRIPTION
Adds support for detecting the presence of a timezone,
detected by a '+' e.g. in:
* 2019-11-26 02:55:41+00:0
* 2019-11-26 02:55:41.298430+00:00

Refactors by extraction, the datetime string parser, into
a helper function that resides spanner/dbapi and is more testable.

Fixes #78