### PR TITLE
dbapi: use sentinel type TimestampStr type to indicate Spanner.TIMESTAMP

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -22,7 +22,8 @@ from .exceptions import (
     Warning,
 )
 from .parse_utils import (
-    extract_connection_params, parse_spanner_url, validate_instance_config,
+    extract_connection_params, infer_param_types, parse_spanner_url,
+    validate_instance_config,
 )
 from .types import (
     BINARY, DATETIME, NUMBER, ROWID, STRING, Date, DateFromTicks, Time,
@@ -123,7 +124,7 @@ __all__ = [
     'DatabaseError', 'DataError', 'Error', 'IntegrityError', 'InterfaceError',
     'InternalError', 'NotSupportedError', 'OperationalError', 'ProgrammingError',
     'Warning', 'USER_AGENT', 'apilevel', 'connect', 'paramstyle', 'threadsafety',
-    'extract_connection_params', 'parse_spanner_url',
+    'extract_connection_params', 'infer_param_types', 'parse_spanner_url',
     'Date', 'DateFromTicks', 'Time', 'TimeFromTicks', 'Timestamp', 'TimestampFromTicks',
-    'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID',
+    'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID', 'TimestampStr',
 ]

--- a/spanner/dbapi/types.py
+++ b/spanner/dbapi/types.py
@@ -88,3 +88,13 @@ class ROWID(object):
     """
     # TODO: Implement me.
     pass
+
+
+class TimestampStr(str):
+    """
+    TimestampStr exists so that we can purposefully format types as timestamps
+    compatible with Cloud Spanner's TIMESTAMP type, but right before making
+    queries, it'll help differentiate between normal strings and the case of
+    types that should be TIMESTAMP.
+    """
+    pass


### PR DESCRIPTION
dbapi: use sentinel type TimestampStr type to indicate Spanner.TIMESTAMP

When performing an UPDATE, Cloud Spanner's transaction methods
have two variants:
a) execute_update
b) insert_or_update

where a) supports a full UPDATE with conditions
but b) has only 3 parameters:
* table
* columns
* values

and b) accepts param_types=None for complex types such as
spanner.TIMESTAMP and it invokes the RPC API. As documented
in
https://cloud.google.com/spanner/docs/data-types#canonical-format_1
the client libraries accept timestamps in the language specific
timestamp format,

WHILE

a) performs and ExecuteSql API request with DML and thus requires
the type to be declared in param_types.

This change depends on its parent PR #81 and will fix the reported
problem, by checking whether our spanner/django/* returned a sentinel
type 'TimestampStr' that inherits from 'str', to indicate that we'll
need to send it as a spanner.TIMESTAMP.

With that change, the repro program:

cur.execute(
  'UPDATE article SET headline = %s, pub_date = %s '
  'WHERE article.id = %s',
  ('Article #1', Timestamp('2005-08-30T01:01:01.000001Z'), 1954819271609460848))

and since TimestampStr is only used by our internal functions, it is
safe to directly infer spanner.TIMESTAMP from it.

While here, also inferring Spanner.BOOL and Spanner.INT64.

Fixes #82