### PR TITLE
spanner/dbapi: only wait for CREATE TABLE operations

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -64,6 +64,4 @@ class Connection(object):
         Returns:
             google.api_core.operation.Operation
         """
-        lro = self.__dbhandle.update_ddl(ddl_statements)
-        # Synchronously wait on the operation's completion.
-        return lro.result()
+        return self.__dbhandle.update_ddl(ddl_statements)


### PR DESCRIPTION
Instead of waiting on every update_ddl long running operation,
only wait for the essential operations that begin with:

    CREATE TABLE

since table creation takes longer, but also tables are
necessary since they are the bread and butter for other
operations and statements.

Fixes #89