### PR TITLE
spanner: implement Connection.drop_db

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -65,3 +65,12 @@ class Connection(object):
             google.api_core.operation.Operation
         """
         return self.__dbhandle.update_ddl(ddl_statements)
+
+    def drop_db(self):
+        """Drop the entire database."""
+        try:
+            return self.__dbhandle.drop()
+        except Exception:
+            raise
+        else:
+            self.close()


### PR DESCRIPTION
Can now drop databases entirely.

Tested out by running

    from spanner.dbapi import connect

    instance_url = 'cloudspanner:/projects/orijtech-161805/instances/django-dev/databases/dbx?instance_config=projects/orijtech-161805/instanceConfigs/regional-us-west2'
    conn = connect(instance_url)
    print(conn.drop_db())

Fixes #95