### PR TITLE
django: fix and fully implement istartswith and iendswith

### DIFF
--- a/spanner/django/base.py
+++ b/spanner/django/base.py
@@ -90,8 +90,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'lte': '<= %s',
         'startswith': 'STARTS_WITH(%s, %%%%s)',
         'endswith': 'ENDS_WITH(%s, %%%%s)',
-        'istartswith': 'REGEXP_CONTAINS(%s, r"^(?i)%s"',
-        'iendswith': 'REGEXP_CONTAINS(%s, r"(?i)%s$"',
+        'istartswith': 'REGEXP_CONTAINS(%s, r"^(?i)%%%%s")',
+        'iendswith': 'REGEXP_CONTAINS(%s, r"(?i)%%%%s$")',
     }
 
     Database = Database

--- a/spanner/django/lookups.py
+++ b/spanner/django/lookups.py
@@ -17,30 +17,64 @@ from django.db.models.lookups import (
 )
 
 
-def endswith(self, compiler, connection):
+def extract_fmtstr_params(self, compiler, connection, is_ends_with=False):
     lhs_sql, params = self.process_lhs(compiler, connection)
     rhs_sql, rhs_params = self.process_rhs(compiler, connection)
     params.extend(rhs_params)
     rhs_sql = self.get_rhs_op(connection, rhs_sql)
-    # Chop leading '%' from param since this isn't a LIKE query.
-    params[0] = params[0][1:]
-    # rhs_sql is 'STARTS_WITH(%s, %%s)' and lhs_sql is the column name.
+    if is_ends_with:
+        params[0] = params[0][1:]
+    else:
+        params[0] = params[0][:-1]
+
     return rhs_sql % lhs_sql, params
+
+
+def fmtstr_params_for_regexp_contains(self, compiler, connection, is_ends_with):
+    """
+    Extract the format string for istartswith and iendswith whose
+    underlying implementation uses REGEXP_CONTAINS(%s, 'r"(?i)%s"',
+    but unfortunately if we let parameters be bound at exec time,
+    they'll just be replaced with the @variable which makes invalid
+    Cloud Spanner SQL statements.
+
+    In otherwords:
+      Replace all the params inline otherwise we'll be stuck in the situation
+      such as:
+      SQL:
+        SELECT blog_post.id FROM blog_post WHERE REGEXP_CONTAINS(blog_post.title, r"^(?i)@a0")
+      and then
+        Params={'a0': 'Cloud'}, param_types={}
+      which unfortunately won't yield any results.
+      but really we want that inline replacement to be
+      SQL:
+        SELECT blog_post.id FROM blog_post WHERE REGEXP_CONTAINS(blog_post.title, r"^(?i)Cloud")
+    """
+    fmtstr, params = extract_fmtstr_params(self, compiler, connection, is_ends_with)
+
+    for param in params:
+        fmtstr = fmtstr % param
+    return fmtstr, ()
+
+
+def endswith(self, compiler, connection):
+    return extract_fmtstr_params(self, compiler, connection, is_ends_with=True)
 
 
 def startswith(self, compiler, connection):
-    # Same logic as endswith but chop trailing (rather than leading) '%' from
-    # param.
-    lhs_sql, params = self.process_lhs(compiler, connection)
-    rhs_sql, rhs_params = self.process_rhs(compiler, connection)
-    params.extend(rhs_params)
-    rhs_sql = self.get_rhs_op(connection, rhs_sql)
-    params[0] = params[0][:-1]
-    return rhs_sql % lhs_sql, params
+    return extract_fmtstr_params(self, compiler, connection, is_ends_with=False)
+
+
+def istartswith(self, compiler, connection):
+    return fmtstr_params_for_regexp_contains(self, compiler, connection, is_ends_with=False)
+
+
+def iendswith(self, compiler, connection):
+    return fmtstr_params_for_regexp_contains(self, compiler, connection, is_ends_with=True)
 
 
 def register_lookups():
     EndsWith.as_spanner = endswith
-    IEndsWith.as_spanner = endswith
+    IEndsWith.as_spanner = iendswith
     StartsWith.as_spanner = startswith
-    IStartsWith.as_spanner = startswith
+    IStartsWith.as_spanner = istartswith


### PR DESCRIPTION
Fixed up a syntax error with istartswith and iendswith,
but after fixing the syntax error, noticed that on
searching for items, the executed SQL performed
late binding at Cursor.execute time and produced
SQL such as

    SQL: SELECT id FROM tb WHERE REGEXP_CONTAINS(title, r"^(?i)@a0")
    Params: {'a0': 'Cloud'}
    Param_types: {}

which of course doesn't match because of the

    r"^(?i)@a0"

and the correct solution is to perform early binding as
we are extracting the format string for the *fix and params
by inlining those values and then returning () as the params,
thus

    SQL: SELECT id FROM tb WHERE REGEXP_CONTAINS(title, r"^(?i)Cloud")
    Params: None
    Param_types: None

and tested with searches such as

* iendswith:

    from blog import models;models.Post.objects.filter(title__iendswith='v2.0')
    <QuerySet [<Post: Post object (4597668878944160828)>]>

* istartswith:

    from blog import models;models.Post.objects.filter(title__istartswith='Cloud')
    <QuerySet [<Post: Post object (987195282277787866)>,
               <Post: Post object (2490018125439035304)>]>

Fixes #92
Updates #87