### PR TITLE
dbapi: revert conditional LRO synchronous waits

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -64,4 +64,5 @@ class Connection(object):
         Returns:
             google.api_core.operation.Operation
         """
-        return self.__dbhandle.update_ddl(ddl_statements)
+        # Synchronously wait on the operation's completion.
+        return self.__dbhandle.update_ddl(ddl_statements).result()

--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -238,22 +238,7 @@ class Cursor(object):
         if not self.__db_handle:
             raise ProgrammingError('Trying to run an DDL update but no database handle')
 
-        lro = self.__db_handle.update_ddl(ddl_statements)
-
-        if has_create_table_stmt(ddl_statements):
-            # We only care about waiting on the result of CREATE TABLE DDL
-            # statements because tables could be referenced, whereas indices are
-            # most likely to be used not immediately, same thing for ALTER statements.
-            return lro.result()
-        else:
-            return lro
-
-
-def has_create_table_stmt(ddl_statements):
-    for ddl_stmt in ddl_statements:
-        if ddl_stmt.upper().startswith('CREATE TABLE'):
-            return True
-    return False
+        return self.__db_handle.update_ddl(ddl_statements)
 
 
 class Column:


### PR DESCRIPTION
Caution has been requested to deal with ensuring
that we have deterministic behavior. If we ever
need to make these optimizations, we can bring
back these changes.

Reverts PR #90