### PR TITLE
dbapi: retrofit UPDATE statements with missing WHERE clause

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
+    'sqlparse >= 0.3.0',
     'google-cloud >= 0.34.0',
     'google-cloud-spanner >= 1.8.0',
 ]

--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -16,8 +16,9 @@ import google.api_core.exceptions as grpc_exceptions
 
 from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
-    STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, classify_stmt, infer_param_types,
-    parse_insert, rows_for_insert_or_update, sql_pyformat_args_to_spanner,
+    STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, classify_stmt,
+    ensure_where_clause, infer_param_types, parse_insert,
+    rows_for_insert_or_update, sql_pyformat_args_to_spanner,
 )
 
 _UNSET_COUNT = -1
@@ -108,6 +109,7 @@ class Cursor(object):
             raise OperationalError(e.details if hasattr(e, 'details') else e)
 
     def __do_execute_update(self, transaction, sql, params, param_types=None):
+        sql = ensure_where_clause(sql)
         sql, params = sql_pyformat_args_to_spanner(sql, params)
 
         # Given that we now format datetime as a Spanner TimeStamp,

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -15,6 +15,7 @@
 import re
 from urllib.parse import urlparse
 
+import sqlparse
 from google.cloud import spanner_v1 as spanner
 
 from .exceptions import Error
@@ -421,6 +422,16 @@ def infer_param_types(params, param_types):
             param_types = insert_key_in_param_types(key, param_types, spanner.param_types.TIMESTAMP)
 
     return param_types
+
+
+def ensure_where_clause(sql):
+    """
+    Cloud Spanner requires a WHERE clause on UPDATE and DELETE statements.
+    Add a dummy WHERE clause if necessary.
+    """
+    if any(isinstance(token, sqlparse.sql.Where) for token in sqlparse.parse(sql)[0]):
+        return sql
+    return sql + ' WHERE 1=1'
 
 
 def insert_key_in_param_types(key, param_types, spanner_type):

--- a/spanner/django/operations.py
+++ b/spanner/django/operations.py
@@ -30,10 +30,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Cloud Spanner doesn't support TRUNCATE so DELETE instead.
         # A dummy WHERE clause is required.
         if tables:
-            delete_sql = '%s %s %%s %s 1=1;' % (
+            delete_sql = '%s %s %%s;' % (
                 style.SQL_KEYWORD('DELETE'),
                 style.SQL_KEYWORD('FROM'),
-                style.SQL_KEYWORD('WHERE'),
             )
             return [
                 delete_sql % style.SQL_FIELD(self.quote_name(table))


### PR DESCRIPTION
Augments SQL statements missing a WHERE clause with

    WHERE 1=1

Thus for example:

    UPDATE (SELECT * FROM A JOIN c ON ai.id = c.id WHERE cl.ci = 1) SET d=5
    UPDATE T SET A = 1

become:

    UPDATE (SELECT * FROM A JOIN c ON ai.id = c.id WHERE cl.ci = 1) SET d=5 WHERE 1=1
    UPDATE T SET A = 1 WHERE 1=1

Fixes #94