### PR TITLE
django: revert removal of WHERE 1=1 from DELETE

### DIFF
--- a/spanner/django/operations.py
+++ b/spanner/django/operations.py
@@ -30,9 +30,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Cloud Spanner doesn't support TRUNCATE so DELETE instead.
         # A dummy WHERE clause is required.
         if tables:
-            delete_sql = '%s %s %%s;' % (
+            delete_sql = '%s %s %%s %s 1=1;' % (
                 style.SQL_KEYWORD('DELETE'),
                 style.SQL_KEYWORD('FROM'),
+                style.SQL_KEYWORD('WHERE'),
             )
             return [
                 delete_sql % style.SQL_FIELD(self.quote_name(table))


### PR DESCRIPTION
In PR #94, we replaced UPDATE and DELETE callers
with ensure_where_clause but have seen in errors
that that code might not be called, so will
revert that part until we have enough time to fully
investigate the call sequence.

Reverts part of #94