### PR TITLE
dbapi: properly insert WHERE 1=1 in midst of ';' and comments

### DIFF
--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -392,8 +392,20 @@ class ParseUtilsTests(TestCase):
                     'UPDATE T SET r=r*0.9 WHERE id IN (SELECT id FROM items WHERE r / w >= 1.3 AND q > 100)',
                 ),
                 (
-                    'DELETE * FROM TABLE',
-                    'DELETE * FROM TABLE WHERE 1=1',
+                    'DELETE * FROM TABLE;',
+                    'DELETE * FROM TABLE WHERE 1=1;',
+                ),
+                (
+                    'DELETE * FROM TABLE; WHERE 1=1',
+                    'DELETE * FROM TABLE WHERE 1=1; WHERE 1=1',
+                ),
+                (
+                    'DELETE * /* all variables */ FROM TABLE /* foo */; -- other comments',
+                    'DELETE * /* all variables */ FROM TABLE /* foo */ WHERE 1=1; -- other comments',
+                ),
+                (
+                    'DELETE * /* all variables */ FROM TABLE /* foo */ WHERE 1=1; -- already has where',
+                    'DELETE * /* all variables */ FROM TABLE /* foo */ WHERE 1=1; -- already has where',
                 ),
         ]
 


### PR DESCRIPTION
Properly insert the ` WHERE 1=1` in the midst of ';' and comments
where the unhandled edge cases were:

    DELETE * FROM TABLE;
    DELETE * FROM TABLE; WHERE 1=1
    DELETE * /* all variables */ FROM TABLE /* foo */; -- other comments

which now get properly formatted and have WHERE 1=1 affixed as:

    DELETE * FROM TABLE WHERE 1=1;
    DELETE * FROM TABLE WHERE 1=1; WHERE 1=1
    DELETE * /* all variables */ FROM TABLE /* foo */ WHERE 1=1; -- other comments

and that involved searching for the first ';' (aka SQL terminator)
and rewriting SQL statements to include the ` WHERE 1=1` tokens.

Fixes #113
Updates #111