### PR TITLE
django: remove constraint checking stubs

### DIFF
--- a/spanner/django/base.py
+++ b/spanner/django/base.py
@@ -117,4 +117,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             self.connection.autocommit = autocommit
 
     def is_usable(self):
-        raise Exception('unimplemented')
+        if self.connection is None:
+            return False
+        try:
+            # Use a cursor directly, bypassing Django's utilities.
+            self.connection.cursor().execute('SELECT 1')
+        except Database.Error:
+            return False
+        else:
+            return True


### PR DESCRIPTION
Spanner doesn't support disabling constraints.