### PR TITLE
django, dbapi: add adapt_decimalfield_value for Decimal->float

### DIFF
--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -416,6 +416,8 @@ def infer_param_types(params, param_types):
     for key, value in params.items():
         if isinstance(value, bool):
             param_types = insert_key_in_param_types(key, param_types, spanner.param_types.BOOL)
+        elif isinstance(value, float):
+            param_types = insert_key_in_param_types(key, param_types, spanner.param_types.FLOAT64)
         elif isinstance(value, int):
             param_types = insert_key_in_param_types(key, param_types, spanner.param_types.INT64)
         elif isinstance(value, TimestampStr):

--- a/spanner/django/operations.py
+++ b/spanner/django/operations.py
@@ -58,6 +58,15 @@ class DatabaseOperations(BaseDatabaseOperations):
                 raise ValueError("Cloud Spanner does not support timezone-aware datetimes when USE_TZ is False.")
         return TimestampStr(value.isoformat(timespec='microseconds') + 'Z')
 
+    def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
+        """
+        Convert value from decimal.Decimal into float, for a direct mapping
+        and correct serialization with RPCs to Cloud Spanner.
+        """
+        if value is None:
+            return None
+        return float(value)
+
     def get_db_converters(self, expression):
         converters = super().get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -319,9 +319,9 @@ class ParseUtilsTests(TestCase):
     def test_infer_param_types(self):
         cases = [
             (
-                {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z', 'c1': '2019-12-05'},
+                {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z', 'c1': '2019-12-05', 'd1': 10.39},
                 None,
-                {'a1': spanner.param_types.INT64},
+                {'a1': spanner.param_types.INT64, 'd1': spanner.param_types.FLOAT64},
             ),
             (
                 {'a1': 10, 'b1': TimestampStr('2005-08-30T01:01:01.000001Z'), 'c1': '2019-12-05'},
@@ -345,12 +345,13 @@ class ParseUtilsTests(TestCase):
             ),
             ({'a1': 10, 'b1': 'aaaaa08-30T01:01:01.000001Z'}, None, {'a1': spanner.param_types.INT64}),
             (
-                {'a1': 10, 'b1': '2005-08-30T01:01:01.000001', 't1': True, 't2': False},
+                {'a1': 10, 'b1': '2005-08-30T01:01:01.000001', 't1': True, 't2': False, 'f1': 99e9},
                 None,
                 {
                     'a1': spanner.param_types.INT64,
                     't1': spanner.param_types.BOOL,
                     't2': spanner.param_types.BOOL,
+                    'f1': spanner.param_types.FLOAT64,
                 },
             ),
             (


### PR DESCRIPTION
Override DatabaseOperations's adapt_decimal_value method
to convert decimal.Decimal fields directly into float
types that map directly to Cloud Spanner's FLOAT64 type.
While here, also directly infer it.

Fixes #121