### PR TITLE
django: disable supports_timezones feature

### DIFF
--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -3,6 +3,7 @@ from django.db.backends.base.features import BaseDatabaseFeatures
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     supports_foreign_keys = False
+    supports_timezones = False
     supports_transactions = False
     supports_column_check_constraints = False
     supports_table_check_constraints = False


### PR DESCRIPTION
refs #115 (doesn't address all failures but skips tests that failure with "ValueError: Cloud Spanner does not support timezone-aware datetimes when USE_TZ is False.")