### PR TITLE
dbapi: explicitly get session from db pool

### DIFF
--- a/spanner/dbapi/connection.py
+++ b/spanner/dbapi/connection.py
@@ -32,6 +32,7 @@ class Connection(object):
     def close(self):
         self.commit()
         self.__raise_if_already_closed()
+        self._clear_all_sessions()
         self.__dbhandle = None
         self.__closed = True
 
@@ -63,10 +64,18 @@ class Connection(object):
         self.__ops.append((op, table, columns, values))
 
     def cursor(self):
-        session = self.__dbhandle.session()
-        if not session.exists():
-            session.create()
+        session = self._new_session()
         return Cursor(session, self)
+
+    def _new_session(self):
+        return self.__dbhandle._pool.get()
+
+    def _done_with_session(self, session):
+        if session:
+            self.__dbhandle._pool.put(session)
+
+    def _clear_all_sessions(self):
+        return self.__dbhandle._pool.clear()
 
     def update_ddl(self, ddl_statements):
         """

--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -53,10 +53,7 @@ class Cursor(object):
     def close(self):
         self.__commit_preceding_batch()
 
-        if not self.__session:
-            return
-
-        self.__session.delete()
+        self.__db_handle._done_with_session(self.__session)
         self.__session = None
 
     def execute(self, sql, args=None):


### PR DESCRIPTION
The Database API provides a method `session`

    https://googleapis.dev/python/spanner/latest/_modules/google/cloud/spanner_v1/database.html#Database.session

which returns a Session, but unfortunately bypasses
the session pool, yet the database also has an attribute
_pool which is the session pool.

Perhaps we should directly use the code in branch
`bunch-up-transactions-too` which will get rid of the
need to even think of sessions in the Cursor.

A follow-up PR will come up soon.

Fixes #158