### PR TITLE
django: store DurationField as INT64 rather than STRING

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 env:
     # Reuse an available database to speed up Travis tests lest we can
     # get terminations as the underlying tables are created.
-    - GOOGLE_APPLICATION_CREDENTIALS=~/creds.json RUNNING_SPANNER_BACKEND_TESTS=1 DJANGO_TEST_APPS="admin_changelist admin_ordering basic lookup.tests.LookupTests.test_in_bulk_lots_of_ids model_fields.test_uuid" SPANNER_TEST_DB=travisdb1 SPANNER_DROP_DB_ON_EXIT=false
+    - GOOGLE_APPLICATION_CREDENTIALS=~/creds.json RUNNING_SPANNER_BACKEND_TESTS=1 DJANGO_TEST_APPS="admin_changelist admin_ordering basic lookup.tests.LookupTests.test_in_bulk_lots_of_ids model_fields.test_durationfield model_fields.test_uuid" SPANNER_TEST_DB=travisdb1 SPANNER_DROP_DB_ON_EXIT=false
 
 python:
     - "3.7"

--- a/spanner/django/base.py
+++ b/spanner/django/base.py
@@ -39,18 +39,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'DateField': 'DATE',
         'DateTimeField': 'TIMESTAMP',
         'DecimalField': 'FLOAT64',
-        # Django extracts this field with parse_duration by invoking
-        #   https://docs.djangoproject.com/en/2.2/_modules/django/utils/dateparse/#parse_duration
-        # starting from
-        #   https://docs.djangoproject.com/en/2.2/_modules/django/db/models/fields/#DurationField
-        # expecting format "[DD] [HH:[MM:]]ss[.uuuuuu]"
-        # also see
-        #   https://cloud.google.com/spanner/docs/migrating-postgres-spanner#data_types
-        # which recommends either:
-        #   "INT64" if storing the value in milliseconds
-        #  OR
-        #   "STRING" if storing the value in an application-defined interval format.
-        'DurationField': 'STRING(50)',
+        'DurationField': 'INT64',
         'EmailField': 'STRING(%(max_length)s)',
         'FileField': 'STRING(%(max_length)s)',
         'FilePathField': 'STRING(%(max_length)s)',

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -17,6 +17,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'basic.tests.SelectOnSaveTests.test_select_on_save_lying_update',
         # spanner.django monkey patches AutoField to have a default value.
         'basic.tests.ModelTest.test_hash',
+        'model_fields.test_durationfield.TestSerialization.test_dumping',
         'model_fields.test_uuid.TestSerialization.test_dumping',
         # Tests that assume a serial pk.
         'admin_views.tests.AdminViewPermissionsTest.test_history_view',


### PR DESCRIPTION
fixes #169