### PR TITLE
django: store TimeField as TIMESTAMP rather than STRING

### DIFF
--- a/spanner/django/base.py
+++ b/spanner/django/base.py
@@ -56,8 +56,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'SmallAutoField': 'INT64',
         'SmallIntegerField': 'INT64',
         'TextField': 'STRING(MAX)',
-        # With or without the time zone, Spanner expects the time field as a string.
-        'TimeField': 'STRING(50)',
+        'TimeField': 'TIMESTAMP',
         # A UUID4 like 'd9c388b1-184d-4511-a818-3d598cc2f847', 16 bytes, with 4 dashes.
         'UUIDField': 'STRING(36)',
     }

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -54,12 +54,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/orijtech/spanner-orm/issues/170
         'model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_with_use_tz',
         'model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_without_use_tz',
-        # Store TimeField as Timestamp:
-        # https://github.com/orijtech/spanner-orm/issues/167
-        'lookup.test_timefield.TimeFieldLookupTests.test_hour_lookups',
-        'lookup.test_timefield.TimeFieldLookupTests.test_minute_lookups',
-        'lookup.test_timefield.TimeFieldLookupTests.test_second_lookups',
-        'model_fields.test_datetimefield.DateTimeFieldTests.test_datetimes_save_completely',
         # DecimalField lookups crash:
         # https://github.com/orijtech/spanner-orm/issues/168
         'lookup.test_decimalfield.DecimalFieldLookupTests.test_gt',


### PR DESCRIPTION
fixes #167