### PR TITLE
dbapi: try batch creating DDL_statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,11 @@ before_install:
 env:
     global:
         - GOOGLE_APPLICATION_CREDENTIALS=~/creds.json
-        # Reuse the database to speed up tests. Without this, Travis terminates
-        # because of no ouput in 10 minutes while tables are created.
         - RUNNING_SPANNER_BACKEND_TESTS=1
-        - SPANNER_DROP_DB_ON_EXIT=false
     jobs:
-        # For every new job, please increment/use a separate SPANNER_TEST_DB.
-        - DJANGO_TEST_APPS="admin_changelist admin_ordering aggregation annotations basic" SPANNER_TEST_DB=travisdb1
-        - DJANGO_TEST_APPS="bulk_create dates datetimes lookup timezones" SPANNER_TEST_DB=travisdb2
-        - DJANGO_TEST_APPS="model_fields" SPANNER_TEST_DB=travisdb3
+        - DJANGO_TEST_APPS="admin_changelist admin_ordering aggregation annotations basic"
+        - DJANGO_TEST_APPS="bulk_create dates datetimes lookup timezones"
+        - DJANGO_TEST_APPS="model_fields"
 
 python:
     - "3.7"

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 
-ORIGWD=$(pwd)
 # If no SPANNER_TEST_DB is set, generate a unique one
 # so that we can have multiple tests running without
 # conflicting which changes and constraints. We'll always
 # cleanup the created database.
-TEST_DBNAME=${SPANNER_TEST_DB:-testdb-$(date +%F%H%M%S)}
+TEST_DBNAME=${SPANNER_TEST_DB:-testdb-$(python3 -c 'import random; print(random.randint(1e3, 0x7fffffff))')}
 TEST_DBNAME_OTHER="$TEST_DBNAME-other"
 TEST_APPS=${DJANGO_TEST_APPS:-basic}
 INSTANCE_NAME=${SPANNER_TEST_INSTANCE:-django-tests}
@@ -19,6 +18,7 @@ REGION=${SPANNER_TEST_REGION:-regional-us-east4}
 INSTANCE_CONFIG="projects/$PROJECT/instanceConfigs/$REGION"
 
 DBs=($TEST_DBNAME $TEST_DBNAME_OTHER)
+ORIGWD=$(pwd)
 
 function create_db() {
     for DB in ${DBs[*]}


### PR DESCRIPTION
By batching DDL statements in Connection, we
can now create tables magnitudes faster than
previously and thus parallelizes tests with
each test spinning up a fresh database from scratch
and tearing it down on end of the test.

From empirical benchmarks, on my laptop:

To create a database and then run the following tests:
    admin_changelist admin_ordering basic

Being in Palo Alto:
* With a DB in region 'us-east4',  duration of tests: 17m50.047s
* With a DB in region 'us-west-2', duration of tests: 17m14.229s

Fixes #190
Fixes #195