### PR TITLE
.travis.yml: parallelize tests in sets of 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ env:
         - GOOGLE_APPLICATION_CREDENTIALS=~/creds.json
         - RUNNING_SPANNER_BACKEND_TESTS=1
     jobs:
-        - DJANGO_TEST_APPS="admin_changelist admin_ordering aggregation annotations basic"
-        - DJANGO_TEST_APPS="bulk_create dates datetimes lookup timezones"
+        - DJANGO_TEST_APPS="admin_changelist admin_ordering"
+        - DJANGO_TEST_APPS="aggregation annotations"
+        - DJANGO_TEST_APPS="basic bulk_create"
+        - DJANGO_TEST_APPS="dates datetimes"
+        - DJANGO_TEST_APPS="lookup timezones"
         - DJANGO_TEST_APPS="model_fields"
 
 python:


### PR DESCRIPTION
Should hopefully speed the max testing time.
As we add more tests, let's keep adding as many new
lines to keep the test time low.