### PR TITLE
dbapi: implement peeking iterator to retrieve metadata after DQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
         - DJANGO_TEST_APPS="lookup timezones"
         - DJANGO_TEST_APPS="model_fields"
         - DJANGO_TEST_APPS="queries.tests.SubqueryTests queries.test_qs_combinators"
+        - DJANGO_TEST_APPS="raw_query"
+
 python:
     - "3.7"
 cache: pip

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -49,6 +49,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'queries.tests.SubqueryTests.test_related_sliced_subquery',
         'queries.tests.Ticket14056Tests.test_ticket_14056',
         'queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup',
+        'raw_query.tests.RawQueryTests.test_annotations',
+        'raw_query.tests.RawQueryTests.test_get_item',
         'syndication_tests.tests.SyndicationFeedTest.test_rss2_feed',
         'syndication_tests.tests.SyndicationFeedTest.test_latest_post_date',
         'syndication_tests.tests.SyndicationFeedTest.test_rss091_feed',
@@ -59,10 +61,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # datetimes retrieved from the database with the wrong hour when
         # USE_TZ = True: https://github.com/orijtech/spanner-orm/issues/193
         'datetimes.tests.DateTimesTests.test_21432',
-        # Cursor.description returns None on raw queries:
-        # https://github.com/orijtech/spanner-orm/issues/155
-        'timezones.tests.LegacyDatabaseTests.test_raw_sql',
-        'timezones.tests.NewDatabaseTests.test_raw_sql',
         # Unable to infer type for parameter:
         # https://github.com/orijtech/spanner-orm/issues/185
         'timezones.tests.LegacyDatabaseTests.test_cursor_execute_returns_naive_datetime',

--- a/tests/spanner/dbapi/test_types.py
+++ b/tests/spanner/dbapi/test_types.py
@@ -15,6 +15,7 @@
 import datetime
 from unittest import TestCase
 
+from spanner.dbapi.cursor import PeekIterator
 from spanner.dbapi.types import (
     Date, DateFromTicks, Time, TimeFromTicks, Timestamp, TimestampFromTicks,
 )
@@ -76,3 +77,18 @@ class TypesTests(TestCase):
         )
         matches = got in want
         self.assertTrue(matches, '`%s` not present in any of\n`%s`' % (got, want))
+
+    def test_PeekIterator(self):
+        cases = [
+            ('list', [1, 2, 3, 4, 6, 7], [1, 2, 3, 4, 6, 7]),
+            ('iter_from_list', iter([1, 2, 3, 4, 6, 7]), [1, 2, 3, 4, 6, 7]),
+            ('tuple', ('a', 12, 0xff,), ['a', 12, 0xff]),
+            ('iter_from_tuple', iter(('a', 12, 0xff,)), ['a', 12, 0xff]),
+            ('no_args', (), []),
+        ]
+
+        for name, data_in, want in cases:
+            with self.subTest(name=name):
+                pitr = PeekIterator(data_in)
+                got = list(pitr)
+                self.assertEqual(got, want)


### PR DESCRIPTION
Read the first element after a DQL in order to populate
res.metadata from
    https://googleapis.dev/python/spanner/latest/streamed-api.html#module-google.cloud.spanner_v1.streamed
which is only populated after a read.

However, in order to ensure that we still return the results
as expected from the iterator's outward perspective, use
a custom iterator that performs the peek and reads from the
various iterators until all iterators have been exhausted.

Also while here noticed that Column needs to be subscriptable
for Django's `raw_query` app to run.

Also enabled previously skipped tests, now that they are supported:
* 'timezones.tests.LegacyDatabaseTests.test_raw_sql'
* 'timezones.tests.NewDatabaseTests.test_raw_sql'

Fixes #155