### PR TITLE
dbapi: add STRING param type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
         - DJANGO_TEST_APPS="dates datetimes"
         - DJANGO_TEST_APPS="lookup timezones"
         - DJANGO_TEST_APPS="model_fields"
-        - DJANGO_TEST_APPS="queries.tests.SubqueryTests queries.test_qs_combinators"
+        - DJANGO_TEST_APPS="queries.tests.SubqueryTests queries.test_bulk_update queries.test_qs_combinators"
         - DJANGO_TEST_APPS="raw_query"
 
 python:

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -436,6 +436,8 @@ def infer_param_types(params, param_types):
             param_types = insert_key_in_param_types(key, param_types, spanner.param_types.TIMESTAMP)
         elif isinstance(value, DateStr):
             param_types = insert_key_in_param_types(key, param_types, spanner.param_types.DATE)
+        elif isinstance(value, str):
+            param_types = insert_key_in_param_types(key, param_types, spanner.param_types.STRING)
 
     return param_types
 

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -21,6 +21,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'model_fields.test_durationfield.TestSerialization.test_dumping',
         'model_fields.test_uuid.TestSerialization.test_dumping',
         'model_fields.test_booleanfield.ValidationTest.test_nullbooleanfield_blank',
+        'queries.test_bulk_update.BulkUpdateNoteTests.test_unsaved_models',
         'timezones.tests.LegacyDatabaseTests.test_cursor_execute_accepts_naive_datetime',
         'timezones.tests.NewDatabaseTests.test_cursor_execute_accepts_naive_datetime',
         # Tests that assume a serial pk.
@@ -106,4 +107,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # Cloud Spanner's docs: "The rows that are returned by LIMIT and OFFSET
         # is unspecified unless these operators are used after ORDER BY."
         'queries.tests.SubqueryTests.test_slice_subquery_and_query',
+        # Cloud Spanner limit: "Number of functions exceeds the maximum
+        # allowed limit of 1000."
+        'queries.test_bulk_update.BulkUpdateTests.test_large_batch',
     )

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -14,7 +14,7 @@
 
 from unittest import TestCase
 
-from google.cloud import spanner_v1 as spanner
+from google.cloud.spanner_v1 import param_types
 from spanner.dbapi.exceptions import Error
 from spanner.dbapi.parse_utils import (
     STMT_DDL, STMT_NON_UPDATING, DateStr, TimestampStr, classify_stmt,
@@ -328,58 +328,68 @@ class ParseUtilsTests(TestCase):
             (
                 {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z', 'c1': '2019-12-05', 'd1': 10.39},
                 None,
-                {'a1': spanner.param_types.INT64, 'd1': spanner.param_types.FLOAT64},
+                {
+                    'a1': param_types.INT64,
+                    'b1': param_types.STRING,
+                    'c1': param_types.STRING,
+                    'd1': param_types.FLOAT64,
+                },
             ),
             (
                 {'a1': 10, 'b1': TimestampStr('2005-08-30T01:01:01.000001Z'), 'c1': '2019-12-05'},
                 None,
-                {'a1': spanner.param_types.INT64, 'b1': spanner.param_types.TIMESTAMP},
+                {'a1': param_types.INT64, 'b1': param_types.TIMESTAMP, 'c1': param_types.STRING},
             ),
             (
                 {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z', 'c1': DateStr('2019-12-05')},
                 None,
-                {'a1': spanner.param_types.INT64, 'c1': spanner.param_types.DATE},
+                {'a1': param_types.INT64, 'b1': param_types.STRING, 'c1': param_types.DATE},
             ),
             (
                 {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z'},
                 {},
-                {'a1': spanner.param_types.INT64},
+                {'a1': param_types.INT64, 'b1': param_types.STRING},
             ),
             (
                 {'a1': 10, 'b1': TimestampStr('2005-08-30T01:01:01.000001Z'), 'c1': DateStr('2005-08-30')},
                 {},
-                {'a1': spanner.param_types.INT64, 'b1': spanner.param_types.TIMESTAMP, 'c1': spanner.param_types.DATE},
+                {'a1': param_types.INT64, 'b1': param_types.TIMESTAMP, 'c1': param_types.DATE},
             ),
-            ({'a1': 10, 'b1': 'aaaaa08-30T01:01:01.000001Z'}, None, {'a1': spanner.param_types.INT64}),
+            (
+                {'a1': 10, 'b1': 'aaaaa08-30T01:01:01.000001Z'},
+                None,
+                {'a1': param_types.INT64, 'b1': param_types.STRING},
+            ),
             (
                 {'a1': 10, 'b1': '2005-08-30T01:01:01.000001', 't1': True, 't2': False, 'f1': 99e9},
                 None,
                 {
-                    'a1': spanner.param_types.INT64,
-                    't1': spanner.param_types.BOOL,
-                    't2': spanner.param_types.BOOL,
-                    'f1': spanner.param_types.FLOAT64,
+                    'a1': param_types.INT64,
+                    'b1': param_types.STRING,
+                    't1': param_types.BOOL,
+                    't2': param_types.BOOL,
+                    'f1': param_types.FLOAT64,
                 },
             ),
             (
                 {'a1': 10, 'b1': '2019-11-26T02:55:41.000000Z'},
                 None,
-                {'a1': spanner.param_types.INT64},
+                {'a1': param_types.INT64, 'b1': param_types.STRING},
             ),
             (
                 {'a1': 10, 'b1': TimestampStr('2019-11-26T02:55:41.000000Z')},
                 None,
-                {'a1': spanner.param_types.INT64, 'b1': spanner.param_types.TIMESTAMP},
+                {'a1': param_types.INT64, 'b1': param_types.TIMESTAMP},
             ),
-            ({'a1': 10, 'b1': None}, None, {'a1': spanner.param_types.INT64}),
+            ({'a1': 10, 'b1': None}, None, {'a1': param_types.INT64}),
             (None, None, None),
             (None, {}, {}),
             (None, {'a1': str}, {'a1': str}),
         ]
 
-        for i, (params, param_types, want_param_types) in enumerate(cases):
+        for i, (params, param_types_, want_param_types) in enumerate(cases):
             with self.subTest(i=i):
-                got_param_types = infer_param_types(params, param_types)
+                got_param_types = infer_param_types(params, param_types_)
                 self.assertEqual(got_param_types, want_param_types)
 
     def test_ensure_where_clause(self):


### PR DESCRIPTION
This fixes some Django tests that use CASE WHEN where values were
string integers. Spanner interprets the values as INT64 and gives a
type mismatch error if param_types isn't specified.