### PR TITLE
dbapi: make grpc.FailedPreCondition an IntegrityError, remove INSERT batching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     jobs:
         - DJANGO_TEST_APPS="admin_changelist admin_ordering"
         - DJANGO_TEST_APPS="aggregation annotations"
-        - DJANGO_TEST_APPS="basic bulk_create"
+        - DJANGO_TEST_APPS="basic bulk_create custom_pk"
         - DJANGO_TEST_APPS="dates datetimes"
         - DJANGO_TEST_APPS="lookup timezones"
         - DJANGO_TEST_APPS="model_fields"

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -74,9 +74,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'bulk_create.tests.BulkCreateTests.test_bulk_insert_expressions',
         # To be investigated: https://github.com/orijtech/spanner-orm/issues/135
         'admin_changelist.tests.ChangeListTests.test_multiuser_edit',
-        # FailedPrecondition and AlreadyExists should be raised as IntegrityError:
-        # https://github.com/orijtech/spanner-orm/issues/154
-        'model_fields.test_booleanfield.BooleanFieldTests.test_null_default',
         # Implement DatabaseOperations.datetime_cast_date_sql():
         # https://github.com/orijtech/spanner-orm/issues/170
         'model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_with_use_tz',


### PR DESCRIPTION
Removed INSERT batching which was causing uncaught failures later on
when Cursor.close and Connection.close were invoked and triggered
actual database inserts.

Also converted grpc.FailedpreCondition into a dbapi.IntegrityError

Fixes #154
Fixes #219