### PR TITLE
django: add test database creation and destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,45 +89,20 @@ Time spent  1.6195518970489502
 
 ### Django connection params
 
-Settings should be a dict containing either:
+Django's `DATABASES` setting should point to an existing database:
 
-a) 'SPANNER_URL' as the key and expecting a URL of the form:
-```
-cloudspanner:[//host[:port]]/project/<project_id>/instances/
-<instance-id>/databases/<database-name>?property-name=property-value
-```
-For example:
 ```python
-DATABASE={
+DATABASES = {
     'default': {
-        "SPANNER_URL":  "cloudspanner:/projects/appdev/instances/dev1/databases/db1?"
-                        "instance_config=projects/appdev/instanceConfigs/regional-us-west2"
-    }
-}
-```
-
-b) Otherwise expects parameters whose keys are capitalized and
-are of the form:
-```python
-{
-    "NAME":             "<database_name>",
-    "INSTANCE":         "<instance_name>",
-    "AUTOCOMMIT":       True or False,
-    "READONLY":         True or False,
-    "PROJECT_ID":       "<project_id>",
-    "INSTANCE_CONFIG":  "[instance configuration if using a brand new database]",
-}
-```
-
-for example:
-
-```python
-{
-    "NAME":             "db1",
-    "INSTANCE":         "dev1",
-    "AUTOCOMMIT":       True,
-    "READONLY":         False,
-    "PROJECT_ID":       "appdev",
-    "INSTANCE_CONFIG":  "projects/appdev/instanceConfigs/regional-us-west2",
+        'ENGINE': 'spanner.django',
+        'PROJECT': '<project_id>',
+        'INSTANCE': '<instance_name>',
+        'NAME': '<database_name>',
+        # Only include this if you need to specify where to retrieve the
+        # service account JSON for the credentials to connect to Cloud Spanner.
+        'OPTIONS': {
+            'credentials_uri': '<credentials_uri>',
+        },
+    },
 }
 ```

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# exit when any command fails
+set -e
+
 # If no SPANNER_TEST_DB is set, generate a unique one
 # so that we can have multiple tests running without
 # conflicting which changes and constraints. We'll always
@@ -7,53 +10,15 @@
 TEST_DBNAME=${SPANNER_TEST_DB:-testdb-$(python3 -c 'import random; print(random.randint(1e3, 0x7fffffff))')}
 TEST_DBNAME_OTHER="$TEST_DBNAME-other"
 TEST_APPS=${DJANGO_TEST_APPS:-basic}
-INSTANCE_NAME=${SPANNER_TEST_INSTANCE:-django-tests}
+INSTANCE=${SPANNER_TEST_INSTANCE:-django-tests}
 PROJECT=${SPANNER_TEST_PROJECT:-appdev-soda-spanner-staging}
 SETTINGS_FILE="$TEST_DBNAME-settings"
-DROPDB_ON_EXIT=${SPANNER_DROP_DB_ON_EXIT:-true}
-
-# Use "regional-us-east4" to reduce latency to Travis CI, as per:
-# https://devops.stackexchange.com/questions/2488/geographically-where-are-the-travis-ci-jobs-run
-REGION=${SPANNER_TEST_REGION:-regional-us-east4}
-INSTANCE_CONFIG="projects/$PROJECT/instanceConfigs/$REGION"
-
-DBs=($TEST_DBNAME $TEST_DBNAME_OTHER)
-ORIGWD=$(pwd)
-
-function create_db() {
-    for DB in ${DBs[*]}
-    do
-        echo "
-from google.cloud import spanner_v1 as sp
-ins = sp.Client(project='$PROJECT').instance('$INSTANCE_NAME')
-if not ins.exists():
-    ins.configuration_name = '$INSTANCE_CONFIG'
-    lro = ins.create()
-    _ = lro.result()
-    print('Created instance: $INSTANCE_NAME at $INSTANCE_CONFIG')
-
-db = ins.database('$DB')
-if not db.exists():
-    lro = db.create()
-    _ = lro.result()
-    print('Created database: $DB')
-else:
-    print('$DB already exists')
-" | python3 -
-        code=$?
-        if [[ $code -ne 0 ]]
-        then
-            return $code
-        fi
-    done
-}
 
 function checkout_django() {
     mkdir -p django_tests && cd django_tests
     git clone --depth 1 --single-branch --branch spanner-2.2.x https://github.com/timgraham/django.git
     cd django && pip3 install -e .
     pip3 install -r tests/requirements/py3.txt
-    return $?
 }
 
 function create_settings() {
@@ -61,17 +26,15 @@ function create_settings() {
 DATABASES = {
    'default': {
        'ENGINE': 'spanner.django',
-       'SPANNER_URL': "cloudspanner:/projects/$PROJECT/instances/$INSTANCE_NAME/databases/$TEST_DBNAME?instance_config=$INSTANCE_CONFIG",
-        'TEST': {
-            'NAME': "$TEST_DBNAME",
-        },
+       'PROJECT': "$PROJECT",
+       'INSTANCE': "$INSTANCE",
+       'NAME': "$TEST_DBNAME",
    },
    'other': {
        'ENGINE': 'spanner.django',
-       'SPANNER_URL': "cloudspanner:/projects/$PROJECT/instances/$INSTANCE_NAME/databases/$TEST_DBNAME_OTHER?instance_config=$INSTANCE_CONFIG",
-        'TEST': {
-            'NAME': "$TEST_DBNAME_OTHER",
-        },
+       'PROJECT': "$PROJECT",
+       'INSTANCE': "$INSTANCE",
+       'NAME': "$TEST_DBNAME_OTHER",
    },
 }
 SECRET_KEY = 'spanner_tests_secret_key'
@@ -81,59 +44,17 @@ PASSWORD_HASHERS = [
 !
 }
 
-function drop_db() {
-    for DB in ${DBs[*]}
-    do
-        echo "
-from google.cloud import spanner_v1 as sp
-ins = sp.Client(project='$PROJECT').instance('$INSTANCE_NAME')
-if not ins.exists():
-    print('Instance $INSTANCE_NAME does not exist anyways')
-else:
-    db = ins.database('$DB')
-    if db.exists():
-        db.drop()
-        print('Dropped $DB')
-" | python3 -
-         code=$?
-        if [[ $code -ne 0 ]]
-        then
-            return $code
-        fi
-    done
-}
-
 function run_django_tests() {
     cd tests
     create_settings
     echo -e "\033[32mRunning Django tests $TEST_APPS\033[00m"
-    # Using --keepdb here because Django's test suite tries to invoke `DROP DATABASE`
-    # using the Cursor if --keepdb isn't set, yet only the Spanner.Database instance
-    # can drop the database, which we do manually in function `drop_db`.
-    python3 runtests.py $TEST_APPS --verbosity=2 --keepdb --noinput --settings $SETTINGS_FILE
-    return $?
+    python3 runtests.py $TEST_APPS --verbosity=2 --noinput --settings $SETTINGS_FILE
 }
 
 function install_spanner_django() {
     pip3 install .
-    return $?
 }
 
-function cleanup_and_exit() {
-    exitCode=$?
-    msg=$1
-    echo $msg
-    if [[ $DROPDB_ON_EXIT = "true" ]]
-    then
-        drop_db
-    fi
-    cd $ORIGWD
-    exit $exitCode
-}
-
-install_spanner_django || cleanup_and_exit
-create_db || cleanup_and_exit "INSTANCE: $INSTANCE_NAME DB: $TEST_DBNAME and $TEST_DBNAME_OTHER could not be created"
-checkout_django || cleanup_and_exit
-run_django_tests || cleanup_and_exit
-# Unconditionally clean up before exit.
-cleanup_and_exit
+install_spanner_django
+checkout_django
+run_django_tests

--- a/spanner/django/creation.py
+++ b/spanner/django/creation.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from unittest import skip
 
 from django.conf import settings
@@ -25,6 +26,44 @@ class DatabaseCreation(BaseDatabaseCreation):
             self.mark_skips()
         super().create_test_db(*args, **kwargs)
 
+    def _create_test_db(self, verbosity, autoclobber, keepdb=False):
+        # Mostly copied from the base class but removes usage of
+        # _nodb_connection since Spanner doesn't have or need one.
+        test_database_name = self._get_test_db_name()
+        # Don't quote the test database name because google.cloud.spanner_v1
+        # does it.
+        test_db_params = {'dbname': test_database_name}
+        # Create the test database.
+        try:
+            self._execute_create_test_db(None, test_db_params, keepdb)
+        except Exception as e:
+            # If the db should be kept, then no need to do any of the below,
+            # just return and skip it all.
+            if keepdb:
+                return test_database_name
+            self.log('Got an error creating the test database: %s' % e)
+            if not autoclobber:
+                confirm = input(
+                    "Type 'yes' if you would like to try deleting the test "
+                    "database '%s', or 'no' to cancel: " % test_database_name)
+            if autoclobber or confirm == 'yes':
+                try:
+                    if verbosity >= 1:
+                        self.log('Destroying old test database for alias %s...' % (
+                            self._get_database_display_str(verbosity, test_database_name),
+                        ))
+                    self._destroy_test_db(test_database_name, verbosity)
+                    self._execute_create_test_db(None, test_db_params, keepdb)
+                except Exception as e:
+                    self.log('Got an error recreating the test database: %s' % e)
+                    sys.exit(2)
+            else:
+                self.log('Tests cancelled.')
+                sys.exit(1)
+        return test_database_name
+
+    def _execute_create_test_db(self, cursor, parameters, keepdb=False):
+        self.connection.instance.database(parameters['dbname']).create()
+
     def _destroy_test_db(self, test_database_name, verbosity):
-        # Cloud Spanner doesn't support dropping a database.
-        pass
+        self.connection.instance.database(test_database_name).drop()


### PR DESCRIPTION
django: DATABASES setting now takes values like NAME, INSTANCE, and PROJECT rather than SPANNER_URL.
dbiapi: connect() takes database_name, instance_name, and project_name rather than spanner_url.

fixes #217, #221