### PR TITLE
dbapi: cast decimal.Decimal->float in Cursor.execute

### DIFF
--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import decimal
 import re
 from urllib.parse import urlparse
 
@@ -412,9 +413,17 @@ def sql_pyformat_args_to_spanner(sql, params):
             resolved_value = pyfmt % params
             named_args[key] = resolved_value
         else:
-            named_args[key] = params[i]
+            named_args[key] = cast_for_spanner(params[i])
 
     return sql, named_args
+
+
+def cast_for_spanner(param):
+    """Convert param to its Cloud Spanner equivalent type."""
+    if isinstance(param, decimal.Decimal):
+        return float(param)
+    else:
+        return param
 
 
 def infer_param_types(params, param_types):

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -78,9 +78,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/orijtech/spanner-orm/issues/170
         'model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_with_use_tz',
         'model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_without_use_tz',
-        # filtering on annotation with Decimal value crashes:
-        # https://github.com/orijtech/spanner-orm/issues/210
-        'annotations.tests.NonAggregateAnnotationTestCase.test_filter_decimal_annotation',
         # using NULL with + crashes: https://github.com/orijtech/spanner-orm/issues/201
         'annotations.tests.NonAggregateAnnotationTestCase.test_combined_annotation_commutative',
         # Spanner loses DecimalField precision due to conversion to float:

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import decimal
 from unittest import TestCase
 
 from google.cloud.spanner_v1 import param_types
@@ -304,6 +305,10 @@ class ParseUtilsTests(TestCase):
                 # since it might be useful to pass to the next user.
                 ('SELECT * from t WHERE id=10', {'f1': 'app', 'f2': 'name'}),
                 ('SELECT * from t WHERE id=10', {'f1': 'app', 'f2': 'name'}),
+            ),
+            (
+                ('SELECT (an.p + %s) AS np FROM an WHERE (an.p + %s) = %s', (1, 1.0, decimal.Decimal('31'),)),
+                ('SELECT (an.p + @a0) AS np FROM an WHERE (an.p + @a1) = @a2', {'a0': 1, 'a1': 1.0, 'a2': 31.0}),
             ),
         ]
         for ((sql_in, params), sql_want) in cases:


### PR DESCRIPTION
Somehow spanner.django.DatabaseOperations isn't invoking
adapt_decimalfield_value to convert decimal.Decimal
thus these values are passed into Cursor.execute e.g.

    SQ: SELECT (annotations_book.price + @a0) AS new_price FROM
        annotations_book WHERE (annotations_book.price + @a1) = @a2

    Params: (1, 1.0, Decimal('31'))

Thus this change, consolidates that cast into spanner.dbapi.parse_utils.

Fixes #210