### PR TITLE
dbapi: INSERT parser to handle expressions

### DIFF
--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -7,7 +7,7 @@ set -e
 # so that we can have multiple tests running without
 # conflicting which changes and constraints. We'll always
 # cleanup the created database.
-TEST_DBNAME=${SPANNER_TEST_DB:-$(python3 -c 'import os; print("a"+os.urandom(10).hex())')}
+TEST_DBNAME=${SPANNER_TEST_DB:-$(python3 -c 'import os, time; print(chr(ord("a") + time.time_ns() % 26)+os.urandom(10).hex())')}
 TEST_DBNAME_OTHER="$TEST_DBNAME-ot"
 TEST_APPS=${DJANGO_TEST_APPS:-basic}
 INSTANCE=${SPANNER_TEST_INSTANCE:-django-tests}

--- a/spanner/dbapi/parser.py
+++ b/spanner/dbapi/parser.py
@@ -1,0 +1,255 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Grammar for parsing VALUES:
+    VALUES      := `VALUES(` + ARGS + `)`
+    ARGS        := [EXPR,]*EXPR
+    EXPR        := TERMINAL / FUNC
+    TERMINAL    := `%s`
+    FUNC        := alphanum + `(` + ARGS + `)`
+    alphanum    := (a-zA-Z_)[0-9a-ZA-Z_]*
+
+thus given:
+    statement: 'VALUES (%s, %s), (%s, LOWER(UPPER(%s)))   , (%s)'
+    It'll parse:
+        VALUES
+            |- ARGS
+                |- (TERMINAL, TERMINAL)
+                |- (TERMINAL, FUNC
+                                |- FUNC
+                                    |- (TERMINAL)
+                |- (TERMINAL)
+"""
+
+from .exceptions import ProgrammingError
+
+ARGS = 'ARGS'
+EXPR = 'EXPR'
+FUNC = 'FUNC'
+TERMINAL = 'TERMINAL'
+VALUES = 'VALUES'
+
+
+class func:
+    def __init__(self, func_name, args):
+        self.name = func_name
+        self.args = args
+
+    def __str__(self):
+        return '%s%s' % (self.name, self.args)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+        if self.name != other.name:
+            return False
+        if not isinstance(other.args, type(self.args)):
+            return False
+        if len(self.args) != len(other.args):
+            return False
+        return self.args == other.args
+
+    def __len__(self):
+        return len(self.args)
+
+
+class terminal(str):
+    """
+    terminal represents the unit symbol that can be part of a SQL values clause.
+    """
+    pass
+
+
+class a_args:
+    def __init__(self, argv):
+        self.argv = argv
+
+    def __str__(self):
+        return '(' + ', '.join([str(arg) for arg in self.argv]) + ')'
+
+    def __repr__(self):
+        return self.__str__()
+
+    def has_expr(self):
+        return any([token for token in self.argv if not isinstance(token, terminal)])
+
+    def __len__(self):
+        return len(self.argv)
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+
+        s_len, o_len = len(self), len(other)
+        if s_len != o_len:
+            return False
+
+        for i, s_item in enumerate(self):
+            o_item = other[i]
+            if s_item != o_item:
+                return False
+
+        return True
+
+    def __getitem__(self, index):
+        return self.argv[index]
+
+    def homogenous(self):
+        """
+        Return True if all the arguments are pyformat
+        args and have the same number of arguments.
+        """
+        if not self.all_have_same_argc():
+            return False
+
+        for arg in self.argv:
+            if isinstance(arg, terminal):
+                continue
+            elif isinstance(arg, a_args):
+                if not arg.homogenous():
+                    return False
+            else:
+                return False
+        return True
+
+    def all_have_same_argc(self):
+        """
+        Return False if all the arguments have the same length.
+        """
+        if len(self) == 0:
+            return True
+
+        arg0_len = len(self.argv[0])
+        for arg in self.argv[1:]:
+            if len(arg) != arg0_len:
+                return False
+
+        return True
+
+
+class values(a_args):
+    def __str__(self):
+        return 'VALUES%s' % super().__str__()
+
+
+def parse_values(stmt):
+    return expect(stmt, VALUES)
+
+
+pyfmt_str = terminal('%s')
+
+
+def expect(word, token):
+    word = word.strip(' ')
+    if token == VALUES:
+        if not word.startswith('VALUES'):
+            raise ProgrammingError('VALUES: `%s` does not start with VALUES' % word)
+        word = word[len('VALUES'):].strip(' ')
+
+        all_args = []
+        while word:
+            word = word.strip(' ')
+
+            word, arg = expect(word, ARGS)
+            all_args.append(arg)
+
+            word = word.strip(' ')
+            if word == '':
+                break
+            elif word[0] != ',':
+                raise ProgrammingError('VALUES: expected `,` got %s in %s' % (word[0], word))
+            else:
+                word = word[1:]
+        return '', values(all_args)
+
+    elif token == TERMINAL:
+        word = word.strip(' ')
+        if word != '%s':
+            raise ProgrammingError('TERMINAL: `%s` is not %%s' % word)
+        return '', pyfmt_str
+
+    elif token == FUNC:
+        begins_with_letter = word and (word[0].isalpha() or word[0] == '_')
+        if not begins_with_letter:
+            raise ProgrammingError('FUNC: `%s` does not begin with `a-zA-z` nor a `_`' % word)
+
+        rest = word[1:]
+        end = 0
+        for ch in rest:
+            if ch.isalnum() or ch == '_':
+                end += 1
+            else:
+                break
+
+        func_name, rest = word[:end+1], word[end+1:].strip(' ')
+
+        word, args = expect(rest, ARGS)
+        return word, func(func_name, args)
+
+    elif token == ARGS:
+        # The form should be:
+        #   (%s)
+        #   (%s, %s...)
+        #   (FUNC, %s...)
+        #   (%s, %s...)
+        if not (word and word[0] == '('):
+            raise ProgrammingError('ARGS: supposed to begin with `(` in `%s`' % (word))
+
+        word = word[1:]
+
+        terms = []
+        while True:
+            word = word.strip(' ')
+            if not word:
+                break
+            elif word == '%s':
+                terms.append(pyfmt_str)
+                word = ''
+            elif word.startswith(')'):
+                break
+            elif not word.startswith('%s'):
+                word, parsed = expect(word, FUNC)
+                terms.append(parsed)
+            else:
+                terms.append(pyfmt_str)
+                word = word[2:].strip(' ')
+
+            if word and word[0] == ',':
+                word = word[1:]
+
+        if (not word) or word[0] != ')':
+            raise ProgrammingError('ARGS: supposed to end with `)` in `%s`' % (word))
+
+        word = word[1:]
+        return word, a_args(terms)
+
+    elif token == EXPR:
+        if word == '%s':
+            # Terminal symbol.
+            return '', (pyfmt_str)
+
+        # Otherwise we expect a function.
+        return expect(word, FUNC)
+
+    else:
+        raise ProgrammingError('Unknown token `%s`' % token)
+
+
+def as_values(values_stmt):
+    _, values = parse_values(values_stmt)
+    return values

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -102,11 +102,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # extract() with timezone not working as expected:
         # https://github.com/orijtech/spanner-orm/issues/191
         'timezones.tests.NewDatabaseTests.test_query_datetimes',
-        # The current approach for inserting (which doesn't use SQL) doesn't
-        # support expressions: https://github.com/orijtech/spanner-orm/issues/198
-        'bulk_create.tests.BulkCreateTests.test_bulk_insert_expressions',
-        'expressions.tests.BasicExpressionsTests.test_new_object_create',
-        'expressions.tests.BasicExpressionsTests.test_new_object_save',
         # To be investigated: https://github.com/orijtech/spanner-orm/issues/135
         'admin_changelist.tests.ChangeListTests.test_multiuser_edit',
         # Implement DatabaseOperations.datetime_cast_date_sql():

--- a/tests/spanner/dbapi/test_parser.py
+++ b/tests/spanner/dbapi/test_parser.py
@@ -1,0 +1,168 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from spanner.dbapi.exceptions import ProgrammingError
+from spanner.dbapi.parser import (
+    ARGS, FUNC, TERMINAL, VALUES, a_args, expect, func, pyfmt_str, values,
+)
+
+
+class ParserTests(TestCase):
+    def test_terminal(self):
+        cases = [
+            ('%s', '', pyfmt_str),
+            ('  %s', '', pyfmt_str),
+            ('  %s   ', '', pyfmt_str),
+        ]
+
+        for text, want_unconsumed, want_parsed in cases:
+            with self.subTest(text=text):
+                got_unconsumed, got_parsed = expect(text, TERMINAL)
+                self.assertEqual(got_parsed, want_parsed)
+                self.assertEqual(got_unconsumed, want_unconsumed)
+
+    def test_terminal_fail(self):
+        cases = [
+            ('', 'TERMINAL: `` is not %s'),
+            ('fdp', 'TERMINAL: `fdp` is not %s'),
+            ('%%s', 'TERMINAL: `%%s` is not %s'),
+            ('%sa', 'TERMINAL: `%sa` is not %s'),
+        ]
+
+        for text, wantException in cases:
+            with self.subTest(text=text):
+                self.assertRaisesRegex(ProgrammingError, wantException, lambda: expect(text, TERMINAL))
+
+    def test_func(self):
+        cases = [
+            ('_91())', ')', func('_91', a_args([]))),
+            ('_a()', '', func('_a', a_args([]))),
+            ('___()', '', func('___', a_args([]))),
+            ('abc()', '', func('abc', a_args([]))),
+            (
+                'AF112(%s, LOWER(%s, %s), rand(%s, %s, TAN(%s, %s)))',
+                '',
+                func('AF112', a_args([
+                    pyfmt_str,
+                    func('LOWER', a_args([pyfmt_str, pyfmt_str])),
+                    func('rand', a_args([
+                        pyfmt_str, pyfmt_str, func('TAN', a_args([pyfmt_str, pyfmt_str])),
+                    ])),
+                ])),
+            ),
+        ]
+
+        for text, want_unconsumed, want_parsed in cases:
+            with self.subTest(text=text):
+                got_unconsumed, got_parsed = expect(text, FUNC)
+                self.assertEqual(got_parsed, want_parsed)
+                self.assertEqual(got_unconsumed, want_unconsumed)
+
+    def test_func_fail(self):
+        cases = [
+            ('', 'FUNC: `` does not begin with `a-zA-z` nor a `_`'),
+            ('91', 'FUNC: `91` does not begin with `a-zA-z` nor a `_`'),
+            ('_91', 'supposed to begin with `\\(`'),
+            ('_91(', 'supposed to end with `\\)`'),
+            ('_.()', 'supposed to begin with `\\(`'),
+            ('_a.b()', 'supposed to begin with `\\(`'),
+        ]
+
+        for text, wantException in cases:
+            with self.subTest(text=text):
+                self.assertRaisesRegex(ProgrammingError, wantException, lambda: expect(text, FUNC))
+
+    def test_a_args(self):
+        cases = [
+            ('()', '', a_args([])),
+            ('(%s)', '', a_args([pyfmt_str])),
+            ('(%s,)', '', a_args([pyfmt_str])),
+            ('(%s),', ',', a_args([pyfmt_str])),
+            (
+                '(%s,%s, f1(%s, %s))', '', a_args([
+                    pyfmt_str, pyfmt_str, func('f1', a_args([pyfmt_str, pyfmt_str])),
+                ]),
+            ),
+        ]
+
+        for text, want_unconsumed, want_parsed in cases:
+            with self.subTest(text=text):
+                got_unconsumed, got_parsed = expect(text, ARGS)
+                self.assertEqual(got_parsed, want_parsed)
+                self.assertEqual(got_unconsumed, want_unconsumed)
+
+    def test_a_args_fail(self):
+        cases = [
+            ('', 'ARGS: supposed to begin with `\\(`'),
+            ('(',  'ARGS: supposed to end with `\\)`'),
+            (')',  'ARGS: supposed to begin with `\\(`'),
+            ('(%s,%s, f1(%s, %s), %s', 'ARGS: supposed to end with `\\)`'),
+        ]
+
+        for text, wantException in cases:
+            with self.subTest(text=text):
+                self.assertRaisesRegex(ProgrammingError, wantException, lambda: expect(text, ARGS))
+
+    def test_expect_values(self):
+        cases = [
+            ('VALUES ()', '', values([a_args([])])),
+            ('VALUES', '', values([])),
+            ('VALUES(%s)', '', values([a_args([pyfmt_str])])),
+            ('    VALUES    (%s)    ', '', values([a_args([pyfmt_str])])),
+            ('VALUES(%s, %s)', '', values([a_args([pyfmt_str, pyfmt_str])])),
+            (
+                'VALUES(%s, %s, LOWER(%s, %s))', '',
+                values([
+                    a_args([
+                        pyfmt_str,
+                        pyfmt_str,
+                        func('LOWER', a_args([pyfmt_str, pyfmt_str])),
+                    ]),
+                ]),
+            ),
+            (
+                'VALUES (UPPER(%s)), (%s)',
+                '',
+                values([
+                    a_args([
+                        func('UPPER', a_args([pyfmt_str])),
+                    ]),
+                    a_args([
+                        pyfmt_str,
+                    ]),
+                ]),
+            ),
+        ]
+
+        for text, want_unconsumed, want_parsed in cases:
+            with self.subTest(text=text):
+                got_unconsumed, got_parsed = expect(text, VALUES)
+                self.assertEqual(got_parsed, want_parsed)
+                self.assertEqual(got_unconsumed, want_unconsumed)
+
+    def test_expect_values_fail(self):
+        cases = [
+            ('', 'VALUES: `` does not start with VALUES'),
+            (
+                'VALUES(%s, %s, (%s, %s))',
+                'FUNC: `\\(%s, %s\\)\\)` does not begin with `a-zA-z` nor a `_`',
+            ),
+            ('VALUES(%s),,', 'ARGS: supposed to begin with `\\(` in `,`'),
+        ]
+
+        for text, wantException in cases:
+            with self.subTest(text=text):
+                self.assertRaisesRegex(ProgrammingError, wantException, lambda: expect(text, VALUES))


### PR DESCRIPTION
dbapi: INSERT parser to handle expressions and unify INSERTs

Handle INSERT with and without expressions
by implementing the grammar for VALUES with
pyformat arguments.

Thus:
    SQL:    INSERT INTO custom_pk_foo (id, bar_id)
            VALUES (%s, LOWER(%s)), (%s, %s), (%s, UPPER(LOWER(%s)))
    Params: (112, 'abcdeA', 113, 'Blue', 114, 'Connection'),

Then gets transformed into:
    txn.execute_sql(
        'INSERT INTO custom_pk_foo (id, bar_id) VALUES
            (@a1, LOWER(@2)), (@a3, @a4), (@a5, UPPER(LOWER(@a6)))',
        params={'a1'...}, param_types={...})

Also while here, hit a weird case where the Python gRPC connector
doesn't commit data to Cloud Spanner unless we try to read from
the StreamedResult. Will report this to the Cloud Spanner team
and to the Python team.

Also unified all INSERT statement types so that they now each 
return 
    [(SQL, params)...]
for any variant of an INSERT statement

and testing this code:

Given DDL
```sql
CREATE TABLE dt (
    id INT64 NOT NULL,
    l STRING(100) NOT NULL,
    m STRING(100) NOT NULL,
) PRIMARY KEY (id)
```

```python
from spanner.dbapi import connect

def main():
    conn = connect(database='db1', instance='django-tests', project='orijtech-161805')

    with conn.cursor() as cur:
        cur.execute(
            'INSERT INTO dt (id, l, m) VALUES (99, "A", "B")', None,
        ) 
        cur.execute(
            'INSERT INTO dt (id, l, m) SELECT 10 as id, "Foo" as l, "Bar" as m', None,
        )
        cur.execute(
            'INSERT INTO dt (id, l, m) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s)',
            (1, 'dates', 'article', 2, 'dates', 'comment', 3, 'dates', 'category'),
        )
        cur.execute(
            'INSERT INTO dt (id, l, m) VALUES (%s, LOWER(%s), %s), (%s, UPPER(%s), %s)',
            (81, 'dates', 'article', 82, 'dates', 'comment'),
        )

    conn.close()

if __name__ == '__main__':
    main()
```
which properly produces
<img width="919" alt="Screen Shot 2019-12-30 at 3 47 39 PM" src="https://user-images.githubusercontent.com/4898263/71605151-bdfff100-2b1b-11ea-9770-bdeeb6ab2800.png">

Fixes #198