### PR TITLE
dbapi: simplify and rename parse_utils.infer_param_types()

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -22,7 +22,7 @@ from .exceptions import (
     Warning,
 )
 from .parse_utils import (
-    extract_connection_params, infer_param_types, parse_spanner_url,
+    extract_connection_params, get_param_types, parse_spanner_url,
 )
 from .types import (
     BINARY, DATETIME, NUMBER, ROWID, STRING, Binary, Date, DateFromTicks, Time,
@@ -85,7 +85,7 @@ __all__ = [
     'DatabaseError', 'DataError', 'Error', 'IntegrityError', 'InterfaceError',
     'InternalError', 'NotSupportedError', 'OperationalError', 'ProgrammingError',
     'Warning', 'USER_AGENT', 'apilevel', 'connect', 'paramstyle', 'threadsafety',
-    'extract_connection_params', 'infer_param_types', 'parse_spanner_url',
+    'extract_connection_params', 'get_param_types', 'parse_spanner_url',
     'Binary', 'Date', 'DateFromTicks', 'Time', 'TimeFromTicks', 'Timestamp',
     'TimestampFromTicks',
     'BINARY', 'STRING', 'NUMBER', 'DATETIME', 'ROWID', 'TimestampStr',

--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -17,7 +17,7 @@ import google.api_core.exceptions as grpc_exceptions
 from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
     STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, classify_stmt,
-    ensure_where_clause, infer_param_types, parse_insert,
+    ensure_where_clause, get_param_types, parse_insert,
     rows_for_insert_or_update, sql_pyformat_args_to_spanner,
 )
 
@@ -111,7 +111,7 @@ class Cursor(object):
         sql = ensure_where_clause(sql)
         sql, params = sql_pyformat_args_to_spanner(sql, params)
 
-        res = transaction.execute_update(sql, params=params, param_types=infer_param_types(params))
+        res = transaction.execute_update(sql, params=params, param_types=get_param_types(params))
         self.__itr = None
         if type(res) == int:
             self.__row_count = res
@@ -164,7 +164,7 @@ class Cursor(object):
             # Reference
             #  https://googleapis.dev/python/spanner/latest/session-api.html#google.cloud.spanner_v1.session.Session.execute_sql
             sql, params = sql_pyformat_args_to_spanner(sql, params)
-            res = snapshot.execute_sql(sql, params=params, param_types=infer_param_types(params))
+            res = snapshot.execute_sql(sql, params=params, param_types=get_param_types(params))
             if type(res) == int:
                 self.__row_count = res
                 self.__itr = None

--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -426,7 +426,7 @@ def cast_for_spanner(param):
         return param
 
 
-def infer_param_types(params):
+def get_param_types(params):
     """
     Return a dictionary of spanner.param_types for a dictionary of parameters.
     """

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -20,7 +20,7 @@ from spanner.dbapi.exceptions import Error
 from spanner.dbapi.parse_utils import (
     STMT_DDL, STMT_NON_UPDATING, DateStr, TimestampStr, classify_stmt,
     ensure_where_clause, escape_name, extract_connection_params,
-    infer_param_types, parse_insert, parse_spanner_url, reINSTANCE_CONFIG,
+    get_param_types, parse_insert, parse_spanner_url, reINSTANCE_CONFIG,
     rows_for_insert_or_update, sql_pyformat_args_to_spanner, strip_backticks,
     validate_instance_config,
 )
@@ -328,7 +328,7 @@ class ParseUtilsTests(TestCase):
                                        lambda: sql_pyformat_args_to_spanner(sql, params),
                                        )
 
-    def test_infer_param_types(self):
+    def test_get_param_types(self):
         cases = [
             (
                 {'a1': 10, 'b1': '2005-08-30T01:01:01.000001Z', 'c1': '2019-12-05', 'd1': 10.39},
@@ -383,7 +383,7 @@ class ParseUtilsTests(TestCase):
 
         for i, (params, want_param_types) in enumerate(cases):
             with self.subTest(i=i):
-                got_param_types = infer_param_types(params)
+                got_param_types = get_param_types(params)
                 self.assertEqual(got_param_types, want_param_types)
 
     def test_ensure_where_clause(self):


### PR DESCRIPTION
Remove the unneeded param_types argument, and rename to get_param_types.