### PR TITLE
django: require RUNNING_SPANNER_BACKEND_TESTS to be set to '1' rather than set to any value

### DIFF
--- a/spanner/django/creation.py
+++ b/spanner/django/creation.py
@@ -22,7 +22,7 @@ class DatabaseCreation(BaseDatabaseCreation):
     def create_test_db(self, *args, **kwargs):
         # This environment variable is set by the Travis build script or
         # by a developer running the tests locally.
-        if os.environ.get('RUNNING_SPANNER_BACKEND_TESTS'):
+        if os.environ.get('RUNNING_SPANNER_BACKEND_TESTS') == '1':
             self.mark_skips()
         super().create_test_db(*args, **kwargs)
 


### PR DESCRIPTION
We have the same approach in Go when dealing with too many environment
variables all with tricky names that become tedious to set/unset. VAR=1/0
IMHO gives better returns than set/unset, with quickly configuring and no
need to re-memorize.