### PR TITLE
all: infer datetime types, monkeypatch DatetimeWithNanoseconds

### DIFF
--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import decimal
 import re
 from functools import reduce
@@ -373,9 +374,9 @@ def get_param_types(params):
             param_types[key] = spanner.param_types.FLOAT64
         elif isinstance(value, int):
             param_types[key] = spanner.param_types.INT64
-        elif isinstance(value, TimestampStr):
+        elif isinstance(value, (TimestampStr, datetime.datetime,)):
             param_types[key] = spanner.param_types.TIMESTAMP
-        elif isinstance(value, DateStr):
+        elif isinstance(value, (DateStr, datetime.date,)):
             param_types[key] = spanner.param_types.DATE
         elif isinstance(value, str):
             param_types[key] = spanner.param_types.STRING

--- a/spanner/django/__init__.py
+++ b/spanner/django/__init__.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 # Monkey-patch AutoField to generate a random value since Cloud Spanner can't
 # do that.
 from uuid import uuid4
 
 from django.db.models.fields import AutoField, Field
+# Monkey-patch google.DatetimeWithNanoseconds's __eq__ compare against datetime.datetime.
+from google.api_core.datetime_helpers import DatetimeWithNanoseconds
 
 from .expressions import register_expressions
 from .functions import register_functions
@@ -39,3 +42,35 @@ def autofield_init(self, *args, **kwargs):
 
 
 AutoField.__init__ = autofield_init
+
+old_datetimewithnanoseconds_eq = getattr(DatetimeWithNanoseconds, '__eq__', None)
+
+
+def datetimewithnanoseconds_eq(self, other):
+    if old_datetimewithnanoseconds_eq:
+        equal = old_datetimewithnanoseconds_eq(self, other)
+        if equal:
+            return True
+        elif type(self) is type(other):
+            return False
+
+    # Otherwise try to convert them to an equvialent form.
+    # See https://github.com/orijtech/spanner-orm/issues/272
+    if isinstance(other, datetime.datetime):
+        return self.ctime() == other.ctime()
+
+    return False
+
+
+DatetimeWithNanoseconds.__eq__ = datetimewithnanoseconds_eq
+
+# Sanity check here since tests can't easily be run for this file:
+if __name__ == '__main__':
+    from django.utils import timezone
+    UTC = timezone.utc
+
+    dt = datetime.datetime(2020, 1, 10, 2, 44, 57, 999, UTC)
+    dtns = DatetimeWithNanoseconds(2020, 1, 10, 2, 44, 57, 999, UTC)
+    equal = dtns == dt
+    if not equal:
+        raise Exception('%s\n!=\n%s' % (dtns, dt))

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import decimal
 from unittest import TestCase
 
@@ -295,6 +296,17 @@ class ParseUtilsTests(TestCase):
             (
                 {'a1': 10, 'b1': '2019-11-26T02:55:41.000000Z'},
                 {'a1': param_types.INT64, 'b1': param_types.STRING},
+            ),
+            (
+                {
+                    'a1': 10, 'b1': TimestampStr('2019-11-26T02:55:41.000000Z'),
+                    'dt1': datetime.datetime(2011, 9, 1, 13, 20, 30),
+                    'd1': datetime.date(2011, 9, 1),
+                },
+                {
+                    'a1': param_types.INT64, 'b1': param_types.TIMESTAMP,
+                    'dt1': param_types.TIMESTAMP, 'd1': param_types.DATE,
+                },
             ),
             (
                 {'a1': 10, 'b1': TimestampStr('2019-11-26T02:55:41.000000Z')},


### PR DESCRIPTION
* Infer

    datetime.date, datetime.datetime

as

    spanner.param_types.(DATE, TIMESTAMP)

respectively

* Monkey-patched DatetimeWithNanoseconds to compare
with datetime.datetime its parent class.

Fixes #185
Fixes #272