### PR TITLE
dbapi: fix paramstyle to 'format'

### DIFF
--- a/spanner/dbapi/__init__.py
+++ b/spanner/dbapi/__init__.py
@@ -22,10 +22,9 @@ from .version import google_client_info
 
 # Globals that MUST be defined ###
 apilevel = "2.0"  # Implements the Python Database API specification 2.0 version.
-# '@' is used by Cloud Spanner as the param style but that style isn't listed
-# in any of the options  https://www.python.org/dev/peps/pep-0249/#paramstyle
-# so we are going with a custom named paramstyle.
-paramstyle = 'at-named'
+# We accept arguments in the format '%s' aka ANSI C print codes.
+# as per https://www.python.org/dev/peps/pep-0249/#paramstyle
+paramstyle = 'format'
 # Threads may not share the module. This is a paranoid threadsafety level, but it is
 # necessary for starters to use when debugging failures. Eventually once transactions
 # are working properly, we'll update the threadsafety level.

--- a/tests/spanner/dbapi/test_globals.py
+++ b/tests/spanner/dbapi/test_globals.py
@@ -12,5 +12,5 @@ from spanner.dbapi import apilevel, paramstyle, threadsafety
 class DBAPIGlobalsTests(TestCase):
     def test_apilevel(self):
         self.assertEqual(apilevel, '2.0', 'We implement PEP-0249 version 2.0')
-        self.assertEqual(paramstyle, 'at-named', 'Cloud Spanner uses @param')
+        self.assertEqual(paramstyle, 'format', 'Cloud Spanner uses @param')
         self.assertEqual(threadsafety, 0, 'Downgraded to the least concurrency')


### PR DESCRIPTION
We previously misunderstood the meaning of paramstyle,
but really it is what the Cursor expects and not what
Spanner expects, since we translate the arguments to be
consumable by Spanner, thus the correct paramstyle is
'format'.

Fixes #282