### PR TITLE
spanner/dbapi: add Cursor.description internal_size and display_size

### DIFF
--- a/spanner/dbapi/cursor.py
+++ b/spanner/dbapi/cursor.py
@@ -27,8 +27,8 @@ _UNSET_COUNT = -1
 # after a row fetch.
 # Since ResultMetadata
 #   https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSetMetadata
-# does not send back the actual size, so we have to lookup size statically.
-# Some field's sizes are dependent upon the dynamic data hence aren't sent back
+# does not send back the actual size, we have to lookup the respective size.
+# Some fields' sizes are dependent upon the dynamic data hence aren't sent back
 # by Cloud Spanner.
 code_to_display_size = {
     param_types.BOOL.code: 1,
@@ -63,12 +63,15 @@ class Cursor(object):
         columns = []
         for field in row_type.fields:
             columns.append(
-                Column(name=field.name,
-                       type_code=field.type.code,
-                       # Size of the SQL type of the column.
-                       display_size=code_to_display_size.get(field.type.code, None),
-                       # Client perceived size of the column.
-                       internal_size=field.ByteSize()))
+                Column(
+                    name=field.name,
+                    type_code=field.type.code,
+                    # Size of the SQL type of the column.
+                    display_size=code_to_display_size.get(field.type.code),
+                    # Client perceived size of the column.
+                    internal_size=field.ByteSize(),
+                )
+            )
         return tuple(columns)
 
     @property


### PR DESCRIPTION
google.*spanner.*ResultSetMetadata's rowType
as per https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSetMetadata
has fields whose attributes include:
* display_size from a statically created lookup table
with sizes determined from  https://cloud.google.com/spanner/docs/data-types#allowable-types
* internal_size from .ByteSize():
From https://github.com/protocolbuffers/protobuf/blob/2e51ad6344111db2e1c38e1c4b78eac5f2029d17/python/google/protobuf/internal/python_message.py#L1046-L1067

display_size is the size of the actual SQL types as stored on the
database
    WHILE
internal_size is the size perceived by the client itself so the
on-wire size

Thus given:

```sql
    CREATE TABLE Venue (
        id STRING(MAX),
        name STRING(MAX),
        age INT64,
        balance FLOAT64
    ) PRIMARY KEY(id)
```

and then a spanner.dbapi.Cursor.execute request

    cursor.execute('SELECT * TABLE")
    print('Description: ', cursor.description)

prints:

    Description:  (Column(name='id', type_code=6, display_size=8, internal_size=8),
        Column(name='name', type_code=6, display_size=8, internal_size=10),
        Column(name='age', type_code=2, display_size=8, internal_size=9),
        Column(name='balance', type_code=3, display_size=8, internal_size=13))

Updates #304