### PR TITLE
django: add null_ok to DatabaseIntrospection.get_table_description()

### DIFF
--- a/spanner/dbapi/autocommit_off_connection.py
+++ b/spanner/dbapi/autocommit_off_connection.py
@@ -7,6 +7,7 @@
 from .autocommit_off_cursor import Cursor
 from .exceptions import Error
 from .periodic_auto_refresh import PeriodicAutoRefreshingTransaction
+from .utils import get_table_column_schema as get_table_column_schema_impl
 
 
 class Connection(object):
@@ -181,3 +182,6 @@ class Connection(object):
               t.table_catalog = '' and t.table_schema = ''
             """)
             return list(res)
+
+    def get_table_column_schema(self, table_name):
+        return get_table_column_schema_impl(self.__connection, table_name)

--- a/spanner/dbapi/autocommit_off_cursor.py
+++ b/spanner/dbapi/autocommit_off_cursor.py
@@ -369,6 +369,9 @@ class Cursor(object):
         # hence this specialized method.
         return self.__connection.list_tables()
 
+    def get_table_column_schema(self, table_name):
+        return self.__connection.get_table_column_schema(table_name)
+
 
 class Column:
     def __init__(self, name, type_code, display_size=None, internal_size=None,

--- a/spanner/dbapi/autocommit_on_connection.py
+++ b/spanner/dbapi/autocommit_on_connection.py
@@ -6,6 +6,7 @@
 
 from .autocommit_on_cursor import Cursor
 from .exceptions import Error
+from .utils import get_table_column_schema as get_table_column_schema_impl
 
 
 class Connection(object):
@@ -110,3 +111,6 @@ class Connection(object):
               t.table_catalog = '' and t.table_schema = ''
             """)
             return list(res)
+
+    def get_table_column_schema(self, table_name):
+        return get_table_column_schema_impl(self.__dbhandle, table_name)

--- a/spanner/dbapi/autocommit_on_cursor.py
+++ b/spanner/dbapi/autocommit_on_cursor.py
@@ -281,6 +281,9 @@ class Cursor(object):
         # hence this specialized method.
         return self.__db_handle.list_tables()
 
+    def get_table_column_schema(self, table_name):
+        return self.__db_handle.get_table_column_schema(table_name)
+
 
 class Column:
     def __init__(self, name, type_code, display_size=None, internal_size=None,

--- a/spanner/django/introspection.py
+++ b/spanner/django/introspection.py
@@ -32,17 +32,23 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         interface.
         """
         cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
-        return [
-            FieldInfo(
-                line.name,
-                line.type_code,
-                # TODO: Fill these in as they're implemented.
-                None,  # display_size
-                None,  # internal_size
-                None,  # precision
-                None,  # scale
-                None,  # null_ok
-                None,  # default
+        column_details = cursor.get_table_column_schema(table_name)
+        descriptions = []
+        for line in cursor.description:
+            column_name, type_code = line[0], line[1]
+            details = column_details[column_name]
+            descriptions.append(
+                FieldInfo(
+                    column_name,
+                    type_code,
+                    # TODO: Fill these in as they're implemented.
+                    None,  # display_size
+                    None,  # internal_size
+                    None,  # precision
+                    None,  # scale
+                    details.null_ok,
+                    None,  # default
+                )
             )
-            for line in cursor.description
-        ]
+
+        return descriptions


### PR DESCRIPTION
INFORMATION_SCHEMA gives us information like:
* column_name
* is_nullable aka null_ok
* spanner_type

which can use to fill in the `null_ok` field for
spanner.django.introspection.DatabaseIntrospection.get_table_description

Updates #248
Updates #308