### PR TITLE
django: implement DatabaseIntrospection.get_primary_key_column() and add get_relations() stub

### DIFF
--- a/spanner/dbapi/autocommit_off_cursor.py
+++ b/spanner/dbapi/autocommit_off_cursor.py
@@ -357,17 +357,10 @@ class Cursor(object):
         return self.__connection.run_prior_DDL_statements()
 
     def list_tables(self):
-        # We CANNOT list tables with
-        #   SELECT
-        #     t.table_name
-        #   FROM
-        #     information_schema.tables AS t
-        #   WHERE
-        #     t.table_catalog = '' and t.table_schema = ''
-        # with a transaction otherwise we get back:
-        #   400 Unsupported concurrency mode in query using INFORMATION_SCHEMA.
-        # hence this specialized method.
         return self.__connection.list_tables()
+
+    def run_sql_in_snapshot(self, sql):
+        return self.__connection.run_sql_in_snapshot(sql)
 
     def get_table_column_schema(self, table_name):
         return self.__connection.get_table_column_schema(table_name)

--- a/spanner/dbapi/autocommit_on_connection.py
+++ b/spanner/dbapi/autocommit_on_connection.py
@@ -89,27 +89,22 @@ class Connection(object):
         return self.__handle_update_ddl(ddl_statements)
 
     def list_tables(self):
-        # We CANNOT list tables with
-        #   SELECT
-        #     t.table_name
-        #   FROM
-        #     information_schema.tables AS t
-        #   WHERE
-        #     t.table_catalog = '' and t.table_schema = ''
-        # with a transaction otherwise we get back:
-        #   400 Unsupported concurrency mode in query using INFORMATION_SCHEMA.
-        # hence this specialized method.
-        self.run_prior_DDL_statements()
-
-        with self.__dbhandle.snapshot() as snapshot:
-            res = snapshot.execute_sql("""
-             SELECT
+        return self.run_sql_in_snapshot("""
+            SELECT
               t.table_name
             FROM
               information_schema.tables AS t
             WHERE
               t.table_catalog = '' and t.table_schema = ''
             """)
+
+    def run_sql_in_snapshot(self, sql):
+        # Some SQL e.g. for INFORMATION_SCHEMA cannot be run in read-write transactions
+        # hence this method exists to circumvent that limit.
+        self.run_prior_DDL_statements()
+
+        with self.__dbhandle.snapshot() as snapshot:
+            res = snapshot.execute_sql(sql)
             return list(res)
 
     def get_table_column_schema(self, table_name):

--- a/spanner/dbapi/autocommit_on_cursor.py
+++ b/spanner/dbapi/autocommit_on_cursor.py
@@ -269,17 +269,10 @@ class Cursor(object):
         return self.__db_handle.run_prior_DDL_statements()
 
     def list_tables(self):
-        # We CANNOT list tables with
-        #   SELECT
-        #     t.table_name
-        #   FROM
-        #     information_schema.tables AS t
-        #   WHERE
-        #     t.table_catalog = '' and t.table_schema = ''
-        # with a transaction otherwise we get back:
-        #   400 Unsupported concurrency mode in query using INFORMATION_SCHEMA.
-        # hence this specialized method.
         return self.__db_handle.list_tables()
+
+    def run_sql_in_snapshot(self, sql):
+        return self.__db_handle.run_sql_in_snapshot(sql)
 
     def get_table_column_schema(self, table_name):
         return self.__db_handle.get_table_column_schema(table_name)

--- a/spanner/django/features.py
+++ b/spanner/django/features.py
@@ -251,9 +251,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # DatabaseIntrospection.get_table_description() isn't fully implemented:
         # https://github.com/orijtech/django-spanner/issues/248
         'introspection.tests.IntrospectionTests.test_get_table_description_col_lengths',
-        # DatabaseIntrospection.get_primary_key_column() isn't implemented:
-        # https://github.com/orijtech/django-spanner/issues/312
-        'introspection.tests.IntrospectionTests.test_get_primary_key_column',
         # DatabaseIntrospection.get_relations() isn't implemented:
         # https://github.com/orijtech/django-spanner/issues/311
         'introspection.tests.IntrospectionTests.test_get_relations',


### PR DESCRIPTION
Implemented:
* DatabaseIntrospection.get_primary_key_column
* DatabaseIntrospection.get_relations

However, get_relations tests CANNOT yet be enabled because
Cloud Spanner doesn't yet have ON DELETE cascading for
FOREIGN KEYS which limits #313, which renders the method
useless as it will always return {} instead of being populated
with values that are derived from FOREIGN KEYs.

Fixes #312
Updates #311