### PR TITLE
dbapi: classify WITH statements

### DIFF
--- a/spanner/dbapi/parse_utils.py
+++ b/spanner/dbapi/parse_utils.py
@@ -22,7 +22,9 @@ STMT_UPDATING = 'UPDATING'
 STMT_INSERT = 'INSERT'
 
 # Heuristic for identifying statements that don't need to be run as updates.
-re_NON_UPDATE = re.compile(r'^\s*(SELECT|ANALYZE|AUDIT|EXPLAIN|SHOW)', re.IGNORECASE)
+re_NON_UPDATE = re.compile(r'^\s*(SELECT)', re.IGNORECASE)
+
+re_WITH = re.compile(r'^\s*(WITH)', re.IGNORECASE)
 
 # DDL statements follow https://cloud.google.com/spanner/docs/data-definition-language
 re_DDL = re.compile(r'^\s*(CREATE|ALTER|DROP)', re.IGNORECASE | re.DOTALL)
@@ -36,6 +38,11 @@ def classify_stmt(sql):
     elif re_IS_INSERT.match(sql):
         return STMT_INSERT
     elif re_NON_UPDATE.match(sql):
+        return STMT_NON_UPDATING
+    elif re_WITH.match(sql):
+        # As of Fri-13th-March-2020, Cloud Spanner only supports WITH for DQL
+        # statements and doesn't yet support WITH for DML statements.
+        # When WITH for DML is added, we'll need to update this classifier accordingly.
         return STMT_NON_UPDATING
     else:
         return STMT_UPDATING

--- a/tests/spanner/dbapi/test_parse_utils.py
+++ b/tests/spanner/dbapi/test_parse_utils.py
@@ -22,7 +22,7 @@ class ParseUtilsTests(TestCase):
         cases = [
                 ('SELECT 1', STMT_NON_UPDATING,),
                 ('SELECT s.SongName FROM Songs AS s', STMT_NON_UPDATING,),
-                ('EXPLAIN app', STMT_NON_UPDATING,),
+                ('WITH sq AS (SELECT SchoolID FROM Roster) SELECT * from sq', STMT_NON_UPDATING,),
                 (
                     'CREATE TABLE django_content_type (id STRING(64) NOT NULL, name STRING(100) '
                     'NOT NULL, app_label STRING(100) NOT NULL, model STRING(100) NOT NULL) PRIMARY KEY(id)',


### PR DESCRIPTION
As of today, Cloud Spanner only supports
WITH for DQL statements, but doesn't support
WITH for DML statements.

This change classifies `WITH` prefixed statements
as DQL statements.

Also while here, removed classification for
AUDIT, ANALYZE, EXPLAIN, SHOW since they aren't
supported by Cloud Spanner.

Fixes #322
Fixes #323