### PR TITLE
dbapi: make fetch* methods return tuple rows instead of list

### DIFF
--- a/spanner/dbapi/utils.py
+++ b/spanner/dbapi/utils.py
@@ -16,6 +16,8 @@ class PeekIterator(object):
     PeekIterator peeks at the first element out of an iterator
     for the sake of operations like auto-population of fields on reading
     the first element.
+    If next's result is an instance of list, it'll be converted into a tuple
+    to conform with DBAPI v2's sequence expectations.
     """
     def __init__(self, source):
         itr_src = iter(source)
@@ -42,7 +44,7 @@ class PeekIterator(object):
             self.__index += 1
             return self.__next__()
         else:
-            return head
+            return tuple(head) if isinstance(head, list) else head
 
     def __iter__(self):
         return self

--- a/tests/spanner/dbapi/test_utils.py
+++ b/tests/spanner/dbapi/test_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+from unittest import TestCase
+
+from spanner.dbapi.utils import PeekIterator
+
+
+class UtilsTests(TestCase):
+    def test_peekIterator_list_rows_converted_to_tuples(self):
+        # Cloud Spanner returns results in lists e.g. [result].
+        # PeekIterator is used by BaseCursor in its fetch* methods.
+        # This test ensures that anything passed into PeekIterator
+        # will be returned as a tuple.
+        pit = PeekIterator([['a'], ['b'], ['c'], ['d'], ['e']])
+        got = list(pit)
+        want = [('a',), ('b',), ('c',), ('d',), ('e',)]
+        self.assertEqual(got, want, 'Rows of type list must be returned as tuples')
+
+        seventeen = PeekIterator([[17]])
+        self.assertEqual(list(seventeen), [(17,)])
+
+        pit = PeekIterator([['%', '%d']])
+        self.assertEqual(next(pit), ('%', '%d',))
+
+        pit = PeekIterator([('Clark', 'Kent')])
+        self.assertEqual(next(pit), ('Clark', 'Kent',))
+
+    def test_peekIterator_nonlist_rows_unconverted(self):
+        pi = PeekIterator(['a', 'b', 'c', 'd', 'e'])
+        got = list(pi)
+        want = ['a', 'b', 'c', 'd', 'e']
+        self.assertEqual(got, want, 'Values should be returned unchanged')


### PR DESCRIPTION
Updates PeekIterator to ensure that if the result to
be returned by __next__ is a list, then it'll get converted
into a tuple; otherwise, the result will be unchanged.

Fixes #340