### PR TITLE
dbapi: implement Cursor.executemany()

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -255,16 +255,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # DatabaseIntrospection.get_relations() isn't implemented:
         # https://github.com/orijtech/django-spanner/issues/311
         'introspection.tests.IntrospectionTests.test_get_relations',
-        # Implement Cursor.executemany():
-        # https://github.com/orijtech/django-spanner/issues/29
-        'backends.base.test_base.ExecuteWrapperTests.test_nested_wrapper_invoked',
-        'backends.base.test_base.ExecuteWrapperTests.test_wrapper_invoked_many',
-        'backends.tests.BackendTestCase.test_cursor_executemany',
-        'backends.tests.BackendTestCase.test_cursor_executemany_with_empty_params_list',
-        'backends.tests.BackendTestCase.test_cursor_executemany_with_iterator',
-        'backends.tests.BackendTestCase.test_cursor_executemany_with_pyformat',
-        'backends.tests.BackendTestCase.test_cursor_executemany_with_pyformat_iterator',
-        'backends.base.test_base.ExecuteWrapperTests.test_database_queried',
         # parameter escaping of % not working correctly:
         # https://github.com/orijtech/django-spanner/issues/347
         'backends.tests.EscapingChecks.test_parameter_escaping',
@@ -275,6 +265,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # pyformat parameters not supported on INSERT:
         # https://github.com/orijtech/django-spanner/issues/343
         'backends.tests.BackendTestCase.test_cursor_execute_with_pyformat',
+        'backends.tests.BackendTestCase.test_cursor_executemany_with_pyformat',
+        'backends.tests.BackendTestCase.test_cursor_executemany_with_pyformat_iterator',
         # duplicate table raises GoogleAPICallError rather than DatabaseError:
         # https://github.com/orijtech/django-spanner/issues/344
         'backends.tests.BackendTestCase.test_duplicate_table_error',

--- a/spanner/dbapi/autocommit_off_cursor.py
+++ b/spanner/dbapi/autocommit_off_cursor.py
@@ -246,9 +246,3 @@ class Cursor(BaseCursor):
     def __clear(self):
         self._connection = None
         self.__txn = None
-
-    def executemany(self, operation, seq_of_params):
-        if not self._connection:
-            raise ProgrammingError('Cursor is not connected to the database')
-
-        raise ProgrammingError('Unimplemented')

--- a/spanner/dbapi/autocommit_on_cursor.py
+++ b/spanner/dbapi/autocommit_on_cursor.py
@@ -172,11 +172,3 @@ class Cursor(BaseCursor):
 
     def __clear(self):
         self._connection = None
-
-    def executemany(self, operation, seq_of_params):
-        self._raise_if_already_closed()
-
-        if not self._connection:
-            raise ProgrammingError('Cursor is not connected to the database')
-
-        raise ProgrammingError('Unimplemented')

--- a/spanner/dbapi/base_cursor.py
+++ b/spanner/dbapi/base_cursor.py
@@ -87,7 +87,8 @@ class BaseCursor(object):
         if not self._connection:
             raise ProgrammingError('Cursor is not connected to the database')
 
-        raise ProgrammingError('Unimplemented')
+        for params in seq_of_params:
+            self.execute(operation, params)
 
     def __next__(self):
         if self._itr is None:


### PR DESCRIPTION
Can now issue Cursor.executemany with for example:

    cur.executemany(
        'INSERT INTO tx1(id, name) VALUES (%s, %s)', [
            (1, 'a',),
            (2, 'b',),
            (3, 'c',),
            (4, 'd',),
            (5, 'e',),
            (6, 'f',),
        ],
    )

Fixes #29