### PR TITLE
dbapi: raise InterfaceError instead of Error, on closed cursor use

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -5,11 +5,13 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 from django.db.backends.base.features import BaseDatabaseFeatures
+from django.db.utils import InterfaceError
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_big_integer_field = False
     can_introspect_duration_field = False
+    closed_cursor_error_class = InterfaceError
     # https://cloud.google.com/spanner/quotas#query_limits
     max_query_params = 950
     supports_foreign_keys = False
@@ -278,7 +280,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # duplicate table raises GoogleAPICallError rather than DatabaseError:
         # https://github.com/orijtech/django-spanner/issues/344
         'backends.tests.BackendTestCase.test_duplicate_table_error',
-        # ProgrammingError or InterfaceError should be raised on an already
-        # closed cursor: https://github.com/orijtech/django-spanner/issues/342
-        'backends.tests.BackendTestCase.test_cursor_contextmanager',
     )

--- a/spanner/dbapi/autocommit_on_cursor.py
+++ b/spanner/dbapi/autocommit_on_cursor.py
@@ -7,9 +7,7 @@
 import google.api_core.exceptions as grpc_exceptions
 
 from .base_cursor import BaseCursor
-from .exceptions import (
-    Error, IntegrityError, OperationalError, ProgrammingError,
-)
+from .exceptions import IntegrityError, OperationalError, ProgrammingError
 from .parse_utils import (
     STMT_DDL, STMT_INSERT, STMT_NON_UPDATING, classify_stmt,
     ensure_where_clause, get_param_types, parse_insert,
@@ -21,13 +19,6 @@ _UNSET_COUNT = -1
 
 
 class Cursor(BaseCursor):
-    def _raise_if_already_closed(self):
-        """
-        Raises an exception if attempting to use an already closed connection.
-        """
-        if self._closed:
-            raise Error('attempting to use an already closed connection')
-
     def close(self):
         self.__clear()
         self._closed = True

--- a/spanner/dbapi/base_connection.py
+++ b/spanner/dbapi/base_connection.py
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-from .exceptions import Error
+from .exceptions import InterfaceError
 from .utils import get_table_column_schema as get_table_column_schema_impl
 
 
@@ -19,7 +19,7 @@ class BaseConnection:
         Raise an exception if attempting to use an already closed connection.
         """
         if self._closed:
-            raise Error('attempting to use an already closed connection')
+            raise InterfaceError('connection already closed')
 
     def __handle_update_ddl(self, ddl_statements):
         """

--- a/spanner/dbapi/base_cursor.py
+++ b/spanner/dbapi/base_cursor.py
@@ -6,7 +6,7 @@
 
 from google.cloud.spanner_v1 import param_types
 
-from .exceptions import Error, ProgrammingError
+from .exceptions import InterfaceError, ProgrammingError
 
 _UNSET_COUNT = -1
 
@@ -68,10 +68,10 @@ class BaseCursor(object):
 
     def _raise_if_already_closed(self):
         """
-        Raises an exception if attempting to use an already closed connection.
+        Raise an exception if attempting to use an already closed connection.
         """
         if self._closed:
-            raise Error('attempting to use an already closed connection')
+            raise InterfaceError('cursor already closed')
 
     def close(self):
         self.__clear()


### PR DESCRIPTION
Follow PostgreSQL's psycopg2 adapter by returning
InterfaceError instead of Error when using a closed cursor.
Also while here, unified the message to match psycopg2's, from

    attempting to use an already closed connection

to

    cursor already closed

and for equivalent code for psycopg2:

```python
import psycopg2

def main():
    with psycopg2.connect('user=emmanuelodeke dbname=postgres') as conn:
        cur = conn.cursor()
        cur.execute('SELECT 1')
        print(cur.fetchall())
        cur.close()
        cur.execute('SELECT 1')
        print(cur.fetchall())
```
which prints:

```shell
[(1,)]
Traceback (most recent call last):
  File "postgresql.py", line 29, in <module>
    main()
  File "postgresql.py", line 11, in main
    cur.execute('SELECT 1')
psycopg2.InterfaceError: cursor already closed
```

and in spanner.dbapi

```python
from spanner.dbapi import connect

def main():
    with connect(instance='django-tests', database='db1', project='orijtech-161805', autocommit=True) as conn:
        cur = conn.cursor()
        cur.execute('SELECT 1')
        print(cur.fetchall())
        cur.close()
        cur.execute('SELECT * from tx1')
        print(cur.fetchall())
```

which prints
```shell
[(1,)]
Traceback (most recent call last):
  File "closed.py", line 15, in <module>
    main()
  File "closed.py", line 11, in main
    cur.execute('SELECT * from tx1')
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/spanner/dbapi/autocommit_on_cursor.py", line 38, in execute
    self._raise_if_already_closed()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/spanner/dbapi/base_cursor.py", line 74, in _raise_if_already_closed
    raise InterfaceError('cursor already closed')
spanner.dbapi.exceptions.InterfaceError: cursor already closed
```

Fixes #342