### PR TITLE
django: fix crash when using + operator with null arguments

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -202,8 +202,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_func_with_timezone',
         'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_week_func',
         'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_week_func_boundaries',
-        # using NULL with + crashes: https://github.com/orijtech/spanner-orm/issues/201
-        'annotations.tests.NonAggregateAnnotationTestCase.test_combined_annotation_commutative',
         # Spanner loses DecimalField precision due to conversion to float:
         # https://github.com/orijtech/spanner-orm/pull/133#pullrequestreview-328482925
         'aggregation.tests.AggregateTestCase.test_decimal_max_digits_has_no_effect',

--- a/django_spanner/operations.py
+++ b/django_spanner/operations.py
@@ -212,6 +212,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         return 'INTERVAL %s MICROSECOND' % sql
 
     def combine_expression(self, connector, sub_expressions):
+        if connector == '+':
+            # Use IFNULL to avoid Spanner's restriction:
+            # "Operands of + cannot be literal NULL".
+            return "IFNULL(%s, 0) + IFNULL(%s, 0)" % tuple(sub_expressions)
         if connector == '%%':
             return 'MOD(%s)' % ', '.join(sub_expressions)
         return super().combine_expression(connector, sub_expressions)


### PR DESCRIPTION
fixes #201