### PR TITLE
dbapi: unescape percent literals (%%) in SQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         - DJANGO_TEST_APPS="queries.test_q queries.test_qs_combinators queries.test_query"
         # Commented out because they take longer 2hr and TravisCI unconditionally terminates them.
         # - DJANGO_TEST_APPS="queries.tests"
-        - DJANGO_TEST_APPS="raw_query redirects_tests reserved_names reverse_lookup"
+        - DJANGO_TEST_APPS="queries.tests.Queries5Tests.test_extra_select_literal_percent_s raw_query redirects_tests reserved_names reverse_lookup"
         - DJANGO_TEST_APPS="save_delete_hooks select_related"
         - DJANGO_TEST_APPS="select_related_onetoone signing sitemaps_tests"
         - DJANGO_TEST_APPS="string_lookup signals"

--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -270,9 +270,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # Cloud Spanner limit: "Number of functions exceeds the maximum
         # allowed limit of 1000."
         'queries.test_bulk_update.BulkUpdateTests.test_large_batch',
-        # QuerySet.extra() with select literal percent doesn't work:
-        # https://github.com/orijtech/spanner-orm/issues/252
-        'queries.tests.Queries5Tests.test_extra_select_literal_percent_s',
         # Spanner doesn't support random ordering.
         'ordering.tests.OrderingTests.test_random_ordering',
         # No matching signature for function MOD for argument types: FLOAT64,
@@ -307,10 +304,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # DatabaseIntrospection.get_relations() isn't implemented:
         # https://github.com/orijtech/django-spanner/issues/311
         'introspection.tests.IntrospectionTests.test_get_relations',
-        # parameter escaping of % not working correctly:
-        # https://github.com/orijtech/django-spanner/issues/347
-        'backends.tests.EscapingChecks.test_parameter_escaping',
-        'backends.tests.EscapingChecksDebug.test_parameter_escaping',
         # Non-ascii SELECT alias crashes "Syntax error: Illegal input character"
         # https://github.com/orijtech/django-spanner/issues/341
         'backends.tests.LastExecutedQueryTest.test_query_encoding',

--- a/spanner/dbapi/utils.py
+++ b/spanner/dbapi/utils.py
@@ -73,3 +73,12 @@ def get_table_column_schema(spanner_db, table_name):
             )
 
         return column_details
+
+
+def unescape_percent_literals(s):
+    """
+    Convert %% (escaped percent literals) to %. Percent signs must be escaped when
+    values like %s are used as SQL parameter placeholders but Spanner's query language
+    uses placeholders like @a0 and doesn't expect percent signs to be escaped.
+    """
+    return s.replace('%%', '%')


### PR DESCRIPTION
Ensures that every site that transforms sql
will unescape escaped SQL format literals %%
into plain %.
Escaped SQL format literals exist because by default
dbapi.Cursor.execute escapes %s as %%s, because %s
is used as the format specifier.
We transform '%s' into '@named' variables so we
should finish up the escaping before uploading the
SQL to Cloud Spanner's server.

Fixes #252
Fixes #347