### PR TITLE
django: fix DatabaseOperations.date_trunc_sql() for TIMESTAMP inputs

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -163,11 +163,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'syndication_tests.tests.SyndicationFeedTest.test_latest_post_date',
         'syndication_tests.tests.SyndicationFeedTest.test_rss091_feed',
         'syndication_tests.tests.SyndicationFeedTest.test_template_feed',
-        # DATE_TRUNC cannot be used on DateTimeField:
-        # https://github.com/orijtech/spanner-orm/issues/182
-        'backends.tests.DateQuotingTest.test_django_date_trunc',
-        'dates.tests.DatesTests.test_dates_trunc_datetime_fields',
-        'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_trunc_func',
         # datetimes retrieved from the database with the wrong hour when
         # USE_TZ = True: https://github.com/orijtech/spanner-orm/issues/193
         'datetimes.tests.DateTimesTests.test_21432',

--- a/django_spanner/operations.py
+++ b/django_spanner/operations.py
@@ -184,11 +184,11 @@ class DatabaseOperations(BaseDatabaseOperations):
             # Spanner truncates to Sunday but Django expects Monday. First,
             # subtract a day so that a Sunday will be truncated to the previous
             # week...
-            field_name = 'DATE_SUB(' + field_name + ', INTERVAL 1 DAY)'
-        sql = 'DATE_TRUNC(%s, %s)' % (field_name, lookup_type)
+            field_name = 'DATE_SUB(CAST(' + field_name + ' AS DATE), INTERVAL 1 DAY)'
+        sql = 'DATE_TRUNC(CAST(%s AS DATE), %s)' % (field_name, lookup_type)
         if lookup_type == 'week':
             # ...then add a day to get from Sunday to Monday.
-            sql = 'DATE_ADD(' + sql + ', INTERVAL 1 DAY)'
+            sql = 'DATE_ADD(CAST(' + sql + ' AS DATE), INTERVAL 1 DAY)'
         return sql
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):


### PR DESCRIPTION
fixes #182