### PR TITLE
django: fix iexact lookup with F expression crash

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -160,9 +160,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # bitrightshift operator gives incorrect result:
         # https://github.com/orijtech/django-spanner/issues/335
         'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_right_shift_operator',
-        # using an F expression as the value of a REGEXP_CONTAINS lookup
-        # crashes: https://github.com/orijtech/django-spanner/issues/251
-        'expressions.tests.BasicExpressionsTests.test_ticket_11722_iexact_lookup',
         # integer division produces a float result, which can't be assigned to
         # an integer column:
         # https://github.com/orijtech/django-spanner/issues/331

--- a/django_spanner/lookups.py
+++ b/django_spanner/lookups.py
@@ -34,7 +34,13 @@ def iexact(self, compiler, connection):
     params.extend(rhs_params)
     rhs_sql = self.get_rhs_op(connection, rhs_sql)
     # Wrap the parameter in ^ and $ to restrict the regex to an exact match.
-    params[0] = '^(?i)%s$' % params[0]
+    if params:
+        params[0] = '^(?i)%s$' % params[0]
+    else:
+        # If no params, then lhs_sql is the expression/column to use as the
+        # regular expression. Use concat to make the value case-insensitive.
+        lhs_sql = "CONCAT('^(?i)', " + lhs_sql + ", '$')"
+        rhs_sql = rhs_sql.replace('%%s', '%s')
     # rhs_sql is REGEXP_CONTAINS(%s, %%s), and lhs_sql is the column name.
     return rhs_sql % lhs_sql, params
 


### PR DESCRIPTION
fixes #251

(aside: the same issue in other lookups will be fixed in #382 and #178)