### PR TITLE
dbapi: use values to make unique named arguments

### DIFF
--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -144,11 +144,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # functions:
         'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_numerical_aggregates',
         'aggregation_regress.tests.AggregationTests.test_stddev',
-        # SELECT list expression references <column> which is neither grouped
-        # nor aggregated: https://github.com/orijtech/spanner-orm/issues/245
-        'aggregation_regress.tests.AggregationTests.test_annotated_conditional_aggregate',
-        'aggregation_regress.tests.AggregationTests.test_annotation_with_value',
-        'expressions.tests.BasicExpressionsTests.test_filtering_on_annotate_that_uses_q',
         # "No matching signature for operator" crash when comparing TIMESTAMP
         # and DATE: https://github.com/orijtech/django-spanner/issues/255
         'expressions.tests.BasicExpressionsTests.test_outerref_mixed_case_table_name',

--- a/tests/spanner_dbapi/test_parse_utils.py
+++ b/tests/spanner_dbapi/test_parse_utils.py
@@ -268,6 +268,46 @@ class ParseUtilsTests(TestCase):
                 ('SELECT (an.p + %s) AS np FROM an WHERE (an.p + %s) = %s', (1, 1.0, decimal.Decimal('31'),)),
                 ('SELECT (an.p + @a0) AS np FROM an WHERE (an.p + @a1) = @a2', {'a0': 1, 'a1': 1.0, 'a2': 31.0}),
             ),
+            (
+                (
+                    'SELECT (an.p + %s) AS np, %s, %s, %s, %s FROM an WHERE (an.p + %s) = %s',
+                    (1, True, False, 0, 1.0, decimal.Decimal('31'), decimal.Decimal('31')),
+                ),
+                (
+                    'SELECT (an.p + @a0) AS np, @a1, @a2, @a3, @a4 FROM an WHERE (an.p + @a5) = @a5',
+                    {'a0': 1, 'a1': True, 'a2': False, 'a3': 0, 'a4': 1.0, 'a5': 31.0},
+                ),
+            ),
+            (
+                (
+                    '''
+                    SELECT
+                        AVG(CASE WHEN c1 < %s THEN dp ELSE 2 END)
+                    FROM (
+                        SELECT
+                            a.id AS Col1,
+                            (a.p * %s) AS dp, a.pg as c1
+                        FROM
+                            a
+                        GROUP BY
+                            a.id, a.p * %s, a.pg
+                    ) subquery''', (400, 0.75, 0.75),
+                ),
+                (
+                    '''
+                    SELECT
+                        AVG(CASE WHEN c1 < @a0 THEN dp ELSE 2 END)
+                    FROM (
+                        SELECT
+                            a.id AS Col1,
+                            (a.p * @a1) AS dp, a.pg as c1
+                        FROM
+                            a
+                        GROUP BY
+                            a.id, a.p * @a1, a.pg
+                    ) subquery''', {'a0': 400, 'a1': 0.75},
+                ),
+            ),
         ]
         for ((sql_in, params), sql_want) in cases:
             with self.subTest(sql=sql_in):


### PR DESCRIPTION
When translating pyformat arguments into named Spanner
query arguments, use the actual value as a key to generate
unique named arguments, instead of always creating a named
argument based of the ordinal number of the current argument.

We encountered a case in which aggregations were failing
because  the arguments in the GROUP BY and those in the
associated SELECT didn't match so for example:

```sql
SELECT
    AVG(CASE WHEN c1 < %s THEN dp ELSE 2 END)
FROM (
    SELECT
        a.id AS Col1, (a.p * %s) AS dp, a.pg as c1
    FROM
        a
    GROUP BY
        a.id, a.p * %s, a.pg
) subquery,

Args: (400, 0.75, 0.75)
```

now produces

```sql
SELECT
    AVG(CASE WHEN c1 < @a0 THEN dp ELSE 2 END)
FROM (
    SELECT
        a.id AS Col1, (a.p * @1) AS dp, a.pg as c1
    FROM
        a
    GROUP BY
        a.id, a.p * @a1, a.pg
) subquery''',

Params: {'a0': 400, 'a1': 0.75}
```

INSTEAD OF:

```sql
SELECT
    AVG(CASE WHEN c1 < @a0 THEN dp ELSE 2 END)
FROM (
    SELECT
        a.id AS Col1, (a.p * @1) AS dp, a.pg as c1
    FROM
        a
    GROUP BY
        a.id, a.p * @a2, a.pg
) subquery''',

Params: {'a0': 400, 'a1': 0.75, 'a2': 0.75}
```

Fixes #245