### PR TITLE
parallelize_tests: create a unique instance per worker

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -62,7 +62,7 @@ then
     # Not using the emulator!
     # Hardcode the max number of workers since Spanner has a very low
     # QPS for administrative RPCs of 5QPS (averaged every 100 seconds)
-    export DJANGO_WORKER_COUNT=4
+    export DJANGO_WORKER_COUNT=5
 else
     export DJANGO_WORKER_COUNT=$(ls .kokoro/presubmit/worker* | wc -l)
     # Install and start the Spanner emulator

--- a/.kokoro/continuous/worker_1.cfg
+++ b/.kokoro/continuous/worker_1.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "1"
-}

--- a/.kokoro/continuous/worker_2.cfg
+++ b/.kokoro/continuous/worker_2.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "2"
-}

--- a/.kokoro/continuous/worker_3.cfg
+++ b/.kokoro/continuous/worker_3.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "3"
-}

--- a/.kokoro/continuous/worker_4.cfg
+++ b/.kokoro/continuous/worker_4.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "4"
-}

--- a/.kokoro/continuous/worker_5.cfg
+++ b/.kokoro/continuous/worker_5.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "5"
-}

--- a/.kokoro/continuous/worker_6.cfg
+++ b/.kokoro/continuous/worker_6.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "6"
-}

--- a/.kokoro/continuous/worker_7.cfg
+++ b/.kokoro/continuous/worker_7.cfg
@@ -1,4 +1,0 @@
-env_vars: {
-    key: "DJANGO_WORKER_INDEX"
-    value: "7"
-}

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -43,21 +43,18 @@ PASSWORD_HASHERS = [
 }
 
 setup_emulator_if_needed() {
-    emulatorHost="$SPANNER_EMULATOR_HOST"
-    if [[ $emulatorHost != "" ]]
+    if [[ $SPANNER_EMULATOR_HOST != "" ]]
     then
         echo "Running the emulator at: $SPANNER_EMULATOR_HOST"
         ./emulator_main --host_port "$SPANNER_EMULATOR_HOST" &
         SPANNER_INSTANCE=$INSTANCE python3 .kokoro/ensure_instance_exists.py
-    else
-        echo 'Not using the emulator'
     fi
 }
 
 run_django_tests() {
     cd $TESTS_DIR/django/tests
     create_settings
-    echo -e "\033[32mRunning Django tests $TEST_APPS\033[00m"
+    echo -e "\033[32mRunning Django tests: $TEST_APPS\033[00m"
     python3 runtests.py $TEST_APPS --verbosity=2 --noinput --settings $SETTINGS_FILE
 }
 


### PR DESCRIPTION
Ensures that each worker creates a unique Spanner instance
which will be DELETED as the worker is exiting!

Potentially solves the issue with very low administrative
quotas for Cloud Spanner, since now each worker will have
its own limits instead of trying to use the exact same instance.

If this works, we'll be able to massively parallelize our tests!

Fixes #413.