### PR TITLE
fix django-spanner install when django and/or google-cloud aren't installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ install_requires = [
 
 setup(
         name='django-spanner',
-        version=__import__('django_spanner').__version__,
+        # Duplicate version here rather than using
+        # __import__('django_spanner').__version__ because that file imports
+        # django and google.cloud which may not be installed.
+        version='2.2a0',
         author='Google LLC',
         author_email='cloud-spanner-developers@googlegroups.com',
         description=('Bridge to enable using Django with Spanner.'),


### PR DESCRIPTION
If setup.py imports django_spanner, Django and google.api_core.datetime_helpers
must be installed before django-spanner.

Regression in 3a244267ffc6cabe847511896a0616fa161d3bfe.