### PR TITLE
parallelize_tests: use looked up region

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -66,7 +66,7 @@ then
     then
         export DJANGO_WORKER_COUNT=1 # Only using 1 worker for continuous instead of $(ls .kokoro/continuous/worker* | wc -l)
     else
-        export DJANGO_WORKER_COUNT=6
+        export DJANGO_WORKER_COUNT=5
     fi
 else
     export DJANGO_WORKER_COUNT=$(ls .kokoro/presubmit/worker* | wc -l)


### PR DESCRIPTION
Despite us getting a quota bump, we continue to see
errors related to creating instances, for example:
https://source.cloud.google.com/results/invocations/7a40c996-e090-495d-945f-8d74f67d8473/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-spanner-django%2Fpresubmit%2Fworker_0/log

    panic: rpc error: code = ResourceExhausted desc = Project 1065521786570 cannot add 1 nodes in region us-west2.

This change lookups the zone and then extrapolates the region
to use when creating the Cloud Spanner instance.