### PR TITLE
django: remove unused DatabaseWrapper.data_types_check_constraints

### DIFF
--- a/django_spanner/base.py
+++ b/django_spanner/base.py
@@ -52,11 +52,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'TimeField': 'TIMESTAMP',
         'UUIDField': 'STRING(32)',
     }
-
-    # TODO: (@odeke-em) examine Spanner's data type constraints.
-    data_types_check_constraints = {
-    }
-
     operators = {
         'exact': '= %s',
         'iexact': 'REGEXP_CONTAINS(%s, %%%%s)',


### PR DESCRIPTION
The proper name is data_type_check_constraints (no 's' after type) but
Spanner doesn't have check constraints anyway.