### PR TITLE
fix: Fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         release_status,
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
Fixes this error on `twine upload`:

```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for classifiers. Error: Classifier 'License :: OSI Approved :: BSD' is not a valid classifier.
```