### PR TITLE
fix: Replace repo name with pkg name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,12 @@ To use this library you'll need a Google Cloud Platform project with the Cloud
 Spanner API enabled. See the `Cloud Spanner Python client docs
 <https://github.com/googleapis/python-spanner/#quick-start>`__ for details.
 
-Use the version of ``python-spanner-django`` that corresponds to your version
-of Django.  For example, ``python-spanner-django`` 2.2.x works with Django
+Use the version of ``django-google-spanner`` that corresponds to your version
+of Django.  For example, ``django-google-spanner`` 2.2.x works with Django
 2.2.y. (This is the only supported version at this time.)
 
 The minor release number of Django doesn't correspond to the minor release
-number of ``python-spanner-django``. Use the latest minor release of each.
+number of ``django-google-spanner``. Use the latest minor release of each.
 
 To install from PyPI:
 
@@ -96,7 +96,7 @@ Limitations
 Transaction management isn't supported
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``python-spanner-django`` always works in ``autocommit`` mode, which is
+``django-google-spanner`` always works in ``autocommit`` mode, which is
 Django's default behavior even for backends that support manual transaction
 management. Transactions cannot be controlled manually with calls like
 ``django.db.transaction.atomic()``.
@@ -105,7 +105,7 @@ management. Transactions cannot be controlled manually with calls like
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Spanner doesn't have support for auto-generating primary key values.
-Therefore, ``python-spanner-django`` monkey-patches ``AutoField`` to generate a
+Therefore, ``django-google-spanner`` monkey-patches ``AutoField`` to generate a
 random UUID4. It generates a default using ``Field``'s ``default`` option which
 means ``AutoField``\ s will have a value when a model instance is created. For
 example:
@@ -126,7 +126,7 @@ were created.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Spanner doesn't support ``ON DELETE CASCADE`` when creating foreign-key
-constraints so ``python-spanner-django`` `doesn't support foreign key
+constraints so ``django-google-spanner`` `doesn't support foreign key
 constraints
 <https://github.com/googleapis/python-spanner-django/issues/313>`__.
 
@@ -177,7 +177,7 @@ Spanner has some limitations on schema changes which you must respect:
 -  Renaming tables and columns isn't supported.
 -  A column's type can't be changed.
 -  A table's primary key can't be altered.
--  Migrations aren't atomic since ``python-spanner-django`` doesn't support
+-  Migrations aren't atomic since ``django-google-spanner`` doesn't support
    transactions.
 
 ``DurationField`` arithmetic doesn't work with ``DateField`` values (`#253 <https://github.com/googleapis/python-spanner-django/issues/253>`__)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-# python-spanner-django documentation build configuration file
+# django-google-spanner documentation build configuration file
 #
 # This file is executedd with the current directory set to its containing dir.
 #
@@ -270,7 +270,7 @@ latex_elements = {
 # latex_documents = [
 #     (
 #         master_doc,
-#         "python-spanner-django.tex",
+#         "django-google-spanner.tex",
 #         u"Spanner Django Documentation",
 #         author,
 #         "manual",
@@ -305,8 +305,8 @@ latex_elements = {
 man_pages = [
     (
         master_doc,
-        "python-spanner-django",
-        u"python-spanner-django Documentation",
+        "django-google-spanner",
+        u"django-google-spanner Documentation",
         [author],
         1,
     )
@@ -324,11 +324,11 @@ man_pages = [
 texinfo_documents = [
     (
         master_doc,
-        "python-spanner-django",
-        u"python-spanner-django Documentation",
+        "django-google-spanner",
+        u"django-google-spanner Documentation",
         author,
-        "python-spanner-django",
-        "python-spanner-django Library",
+        "django-google-spanner",
+        "django-google-spanner Library",
         "APIs",
     )
 ]


### PR DESCRIPTION
Use "django-google-spanner" instead of "python-spanner-django" where appropriate in README and docs.