### PR TITLE
feat: Implementing DB-API types according to the PEP-0249 specification

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -38,9 +38,8 @@ class Connection:
             raise InterfaceError("connection is already closed")
 
     def __handle_update_ddl(self, ddl_statements):
-        """
-        Run the list of Data Definition Language (DDL) statements on the underlying
-        database. Each DDL statement MUST NOT contain a semicolon.
+        """Run the list of Data Definition Language (DDL) statements on the
+        underlying database. Each DDL statement MUST NOT contain a semicolon.
         Args:
             ddl_statements: a list of DDL statements, each without a semicolon.
         Returns:

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -39,8 +39,8 @@ class Connection:
 
     def __handle_update_ddl(self, ddl_statements):
         """
-        Run the list of Data Definition Language (DDL) statements on the
-        underlying database. Each DDL statement MUST NOT contain a semicolon.
+        Run the list of Data Definition Language (DDL) statements on the underlying
+        database. Each DDL statement MUST NOT contain a semicolon.
         Args:
             ddl_statements: a list of DDL statements, each without a semicolon.
         Returns:

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -38,7 +38,8 @@ class Connection:
             raise InterfaceError("connection is already closed")
 
     def __handle_update_ddl(self, ddl_statements):
-        """Run the list of Data Definition Language (DDL) statements on the
+        """
+        Run the list of Data Definition Language (DDL) statements on the
         underlying database. Each DDL statement MUST NOT contain a semicolon.
         Args:
             ddl_statements: a list of DDL statements, each without a semicolon.

--- a/google/cloud/spanner_dbapi/types.py
+++ b/google/cloud/spanner_dbapi/types.py
@@ -12,6 +12,7 @@
 """
 
 import datetime
+from base64 import b64encode
 
 
 def _time_from_ticks(ticks, tz=None):
@@ -27,19 +28,6 @@ def _time_from_ticks(ticks, tz=None):
     :returns: The corresponding time value.
     """
     return datetime.datetime.fromtimestamp(ticks, tz=tz).timetz()
-
-
-def _binary(string):
-    """A helper method used to construct an object capable of
-    holding a binary (long) string value.
-
-    :type string: str
-    :param string: A string to encode as binary bytes.
-
-    :rtype: bytes
-    :returns: The UTF-8 encoded representation of the string.
-    """
-    return string.encode("utf-8")
 
 
 class _DBAPITypeObject(object):
@@ -63,7 +51,7 @@ Timestamp = datetime.datetime
 DateFromTicks = datetime.date.fromtimestamp
 TimeFromTicks = _time_from_ticks
 TimestampFromTicks = datetime.datetime.fromtimestamp
-Binary = _binary
+Binary = b64encode
 
 STRING = "STRING"
 BINARY = _DBAPITypeObject("TYPE_CODE_UNSPECIFIED", "BYTES", "ARRAY", "STRUCT")

--- a/google/cloud/spanner_dbapi/types.py
+++ b/google/cloud/spanner_dbapi/types.py
@@ -12,22 +12,32 @@
 """
 
 import datetime
+import time
 from base64 import b64encode
 
 
-def _time_from_ticks(ticks, tz=None):
-    """A helper method used to construct a DB-API time value.
+def _date_from_ticks(ticks):
+    """Based on PEP-249 Implementation Hints for Module Authors:
 
-    :type ticks: float
-    :param ticks: The number of seconds passed since the epoch.
-
-    :type tz: :class:`datetime.tzinfo`
-    :param tz: (Optional) The timezone information to use for conversion.
-
-    :rtype: :class:`datetime.time`
-    :returns: The corresponding time value.
+    https://www.python.org/dev/peps/pep-0249/#implementation-hints-for-module-authors
     """
-    return datetime.datetime.fromtimestamp(ticks, tz=tz).timetz()
+    return Date(*time.localtime(ticks)[:3])
+
+
+def _time_from_ticks(ticks):
+    """Based on PEP-249 Implementation Hints for Module Authors:
+
+    https://www.python.org/dev/peps/pep-0249/#implementation-hints-for-module-authors
+    """
+    return Time(*time.localtime(ticks)[3:6])
+
+
+def _timestamp_from_ticks(ticks):
+    """Based on PEP-249 Implementation Hints for Module Authors:
+
+    https://www.python.org/dev/peps/pep-0249/#implementation-hints-for-module-authors
+    """
+    return Timestamp(*time.localtime(ticks)[:6])
 
 
 class _DBAPITypeObject(object):
@@ -48,9 +58,9 @@ class _DBAPITypeObject(object):
 Date = datetime.date
 Time = datetime.time
 Timestamp = datetime.datetime
-DateFromTicks = datetime.date.fromtimestamp
+DateFromTicks = _date_from_ticks
 TimeFromTicks = _time_from_ticks
-TimestampFromTicks = datetime.datetime.fromtimestamp
+TimestampFromTicks = _timestamp_from_ticks
 Binary = b64encode
 
 STRING = "STRING"

--- a/tests/spanner_dbapi/test_types.py
+++ b/tests/spanner_dbapi/test_types.py
@@ -43,7 +43,3 @@ class TypesTests(TestCase):
         self.assertEqual(types.DATETIME, "TIMESTAMP")
         self.assertEqual(types.DATETIME, "DATE")
         self.assertNotEqual(types.DATETIME, "STRING")
-
-        self.assertNotEqual("STRING", types.BINARY)
-        self.assertEqual(types.Binary(u"hello"), b"hello")
-        self.assertEqual(types.Binary(u"\u1f60"), u"\u1f60".encode("utf-8"))

--- a/tests/spanner_dbapi/test_types.py
+++ b/tests/spanner_dbapi/test_types.py
@@ -5,27 +5,33 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 import datetime
-import time
+from time import timezone
 from unittest import TestCase
 
-from google.cloud._helpers import UTC
 from google.cloud.spanner_dbapi import types
 
 
-utcOffset = time.timezone  # offset for current timezone
-
-
 class TypesTests(TestCase):
+
+    TICKS = 1572822862.9782631 + timezone  # Sun 03 Nov 2019 23:14:22 UTC
+
+    def test__date_from_ticks(self):
+        actual = types._date_from_ticks(self.TICKS)
+        expected = datetime.date(2019, 11, 3)
+
+        self.assertEqual(actual, expected)
+
     def test__time_from_ticks(self):
-        ticks = 1572822862.9782631  # Sun 03 Nov 2019 23:14:22 UTC
-        timezone = UTC
+        actual = types._time_from_ticks(self.TICKS)
+        expected = datetime.time(23, 14, 22)
 
-        actual = types.TimeFromTicks(ticks, tz=timezone)
-        expected = datetime.datetime.fromtimestamp(ticks, tz=timezone).timetz()
+        self.assertEqual(actual, expected)
 
-        self.assertTrue(
-            actual == expected, "`%s` doesn't match\n`%s`" % (actual, expected)
-        )
+    def test__timestamp_from_ticks(self):
+        actual = types._timestamp_from_ticks(self.TICKS)
+        expected = datetime.datetime(2019, 11, 3, 23, 14, 22)
+
+        self.assertEqual(actual, expected)
 
     def test_type_equal(self):
         self.assertEqual(types.BINARY, "TYPE_CODE_UNSPECIFIED")

--- a/tests/spanner_dbapi/test_utils.py
+++ b/tests/spanner_dbapi/test_utils.py
@@ -10,6 +10,21 @@ from google.cloud.spanner_dbapi.utils import PeekIterator
 
 
 class UtilsTests(TestCase):
+    def test_PeekIterator(self):
+        cases = [
+            ("list", [1, 2, 3, 4, 6, 7], [1, 2, 3, 4, 6, 7]),
+            ("iter_from_list", iter([1, 2, 3, 4, 6, 7]), [1, 2, 3, 4, 6, 7]),
+            ("tuple", ("a", 12, 0xFF), ["a", 12, 0xFF]),
+            ("iter_from_tuple", iter(("a", 12, 0xFF)), ["a", 12, 0xFF]),
+            ("no_args", (), []),
+        ]
+
+        for name, data_in, expected in cases:
+            with self.subTest(name=name):
+                pitr = PeekIterator(data_in)
+                actual = list(pitr)
+                self.assertEqual(actual, expected)
+
     def test_peekIterator_list_rows_converted_to_tuples(self):
         # Cloud Spanner returns results in lists e.g. [result].
         # PeekIterator is used by BaseCursor in its fetch* methods.


### PR DESCRIPTION
The proposed changes represent reworked `types.py` in accordance with the **PEP-0249** [Type Objects and Constructors](https://www.python.org/dev/peps/pep-0249/#type-objects-and-constructors) specifications.

_Some of the classes implemented prior to the alpha release are not part of the DB-API standards. Those were left in for now but may be removed later in the GA release._