### PR TITLE
refactor: refactor Connection() class and cover it with unit tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,8 @@ Format
         },
     }
 
-Example
-~~~~~~~
-
-For example:
+Database configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
@@ -89,6 +87,25 @@ For example:
             'NAME': 'db1', # Or the Cloud Spanner database to use
         }
     }
+
+Execute a query
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    from google.cloud.spanner_dbapi import connect
+
+    connection = connect("instance-id", "database-id")
+    cursor = connection.cursor()
+
+    cursor.execute(
+        "SELECT *"
+        "FROM Singers"
+        "WHERE SingerId = 15"
+    )
+
+    results = cur.fetchall()
+
 
 Limitations
 -----------

--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -217,6 +217,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "admin_views.test_multidb.MultiDatabaseTests.test_change_view",
         "admin_views.test_multidb.MultiDatabaseTests.test_delete_view",
         "auth_tests.test_admin_multidb.MultiDatabaseTests.test_add_view",
+        "auth_tests.test_remote_user_deprecation.RemoteUserCustomTest.test_configure_user_deprecation_warning",
         "contenttypes_tests.test_models.ContentTypesMultidbTests.test_multidb",
         # Tests that by-pass using django_spanner and generate
         # invalid DDL: https://github.com/orijtech/django-spanner/issues/298

--- a/google/cloud/spanner_dbapi/__init__.py
+++ b/google/cloud/spanner_dbapi/__init__.py
@@ -93,7 +93,7 @@ def connect(
     if not database.exists():
         raise ValueError("database '%s' does not exist." % database_id)
 
-    return Connection(database)
+    return Connection(instance, database)
 
 
 __all__ = [

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -12,7 +12,7 @@ import warnings
 from google.cloud import spanner_v1
 
 from .cursor import Cursor
-from .exceptions import InterfaceError, Warning
+from .exceptions import InterfaceError
 
 AUTOCOMMIT_MODE_WARNING = (
     "This method is non-operational, as Cloud Spanner"

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -7,11 +7,18 @@
 """Cloud Spanner DB connection object."""
 
 from collections import namedtuple
+import warnings
 
 from google.cloud import spanner_v1
 
 from .cursor import Cursor
 from .exceptions import InterfaceError, Warning
+
+AUTOCOMMIT_MODE_WARNING = (
+    "This method is non-operational, as Cloud Spanner"
+    "DB API always works in `autocommit` mode."
+    "See https://github.com/googleapis/python-spanner-django#transaction-management-isnt-supported"
+)
 
 ColumnDetails = namedtuple("column_details", ["null_ok", "spanner_type"])
 
@@ -142,17 +149,11 @@ class Connection:
 
     def commit(self):
         """Commit all the pending transactions."""
-        raise Warning(
-            "Cloud Spanner DB API always works in `autocommit` mode."
-            "See https://github.com/googleapis/python-spanner-django#transaction-management-isnt-supported"
-        )
+        warnings.warn(AUTOCOMMIT_MODE_WARNING, UserWarning, stacklevel=2)
 
     def rollback(self):
         """Rollback all the pending transactions."""
-        raise Warning(
-            "Cloud Spanner DB API always works in `autocommit` mode."
-            "See https://github.com/googleapis/python-spanner-django#transaction-management-isnt-supported"
-        )
+        warnings.warn(AUTOCOMMIT_MODE_WARNING, UserWarning, stacklevel=2)
 
     def __enter__(self):
         return self

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -4,22 +4,37 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
+"""Cloud Spanner DB connection object."""
+
 from collections import namedtuple
 
-from google.cloud import spanner_v1 as spanner
+from google.cloud import spanner_v1
 
 from .cursor import Cursor
-from .exceptions import InterfaceError
+from .exceptions import InterfaceError, Warning
 
 ColumnDetails = namedtuple("column_details", ["null_ok", "spanner_type"])
 
 
 class Connection:
-    def __init__(self, db_handle):
-        self._dbhandle = db_handle
-        self._ddl_statements = []
+    """Representation of a connection to a Cloud Spanner database.
 
+    You most likely don't need to instantiate `Connection` objects
+    directly, use the `connect` module function instead.
+
+    :type instance: :class:`~google.cloud.spanner_v1.instance.Instance`
+    :param instance: Cloud Spanner instance to connect to.
+
+    :type database: :class:`~google.cloud.spanner_v1.database.Database`
+    :param database: Cloud Spanner database to connect to.
+    """
+
+    def __init__(self, instance, database):
+        self.instance = instance
+        self.database = database
         self.is_closed = False
+
+        self._ddl_statements = []
 
     def cursor(self):
         self._raise_if_closed()
@@ -48,15 +63,15 @@ class Connection:
         """
         self._raise_if_closed()
         # Synchronously wait on the operation's completion.
-        return self._dbhandle.update_ddl(ddl_statements).result()
+        return self.database.update_ddl(ddl_statements).result()
 
     def read_snapshot(self):
         self._raise_if_closed()
-        return self._dbhandle.snapshot()
+        return self.database.snapshot()
 
     def in_transaction(self, fn, *args, **kwargs):
         self._raise_if_closed()
-        return self._dbhandle.run_in_transaction(fn, *args, **kwargs)
+        return self.database.run_in_transaction(fn, *args, **kwargs)
 
     def append_ddl_statement(self, ddl_statement):
         self._raise_if_closed()
@@ -90,7 +105,7 @@ class Connection:
         # hence this method exists to circumvent that limit.
         self.run_prior_DDL_statements()
 
-        with self._dbhandle.snapshot() as snapshot:
+        with self.database.snapshot() as snapshot:
             res = snapshot.execute_sql(
                 sql, params=params, param_types=param_types
             )
@@ -107,7 +122,7 @@ class Connection:
             AND
                 TABLE_NAME = @table_name""",
             params={"table_name": table_name},
-            param_types={"table_name": spanner.param_types.STRING},
+            param_types={"table_name": spanner_v1.param_types.STRING},
         )
 
         column_details = {}
@@ -122,19 +137,22 @@ class Connection:
 
         The connection will be unusable from this point forward.
         """
-        self.rollback()
         self.__dbhandle = None
         self.is_closed = True
 
     def commit(self):
-        self._raise_if_closed()
-
-        self.run_prior_DDL_statements()
+        """Commit all the pending transactions."""
+        raise Warning(
+            "Cloud Spanner DB API always works in `autocommit` mode."
+            "See https://github.com/googleapis/python-spanner-django#transaction-management-isnt-supported"
+        )
 
     def rollback(self):
-        self._raise_if_closed()
-
-        # TODO: to be added.
+        """Rollback all the pending transactions."""
+        raise Warning(
+            "Cloud Spanner DB API always works in `autocommit` mode."
+            "See https://github.com/googleapis/python-spanner-django#transaction-management-isnt-supported"
+        )
 
     def __enter__(self):
         return self

--- a/tests/spanner_dbapi/test_connection.py
+++ b/tests/spanner_dbapi/test_connection.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 # import google.cloud.spanner_dbapi.exceptions as dbapi_exceptions
 
-from google.cloud.spanner_dbapi import Connection, InterfaceError, Warning
+from google.cloud.spanner_dbapi import Connection, InterfaceError
 from google.cloud.spanner_dbapi.connection import AUTOCOMMIT_MODE_WARNING
 from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1.instance import Instance

--- a/tests/spanner_dbapi/test_connection.py
+++ b/tests/spanner_dbapi/test_connection.py
@@ -7,10 +7,12 @@
 """Connection() class unit tests."""
 
 import unittest
+from unittest import mock
 
 # import google.cloud.spanner_dbapi.exceptions as dbapi_exceptions
 
 from google.cloud.spanner_dbapi import Connection, InterfaceError, Warning
+from google.cloud.spanner_dbapi.connection import AUTOCOMMIT_MODE_WARNING
 from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1.instance import Instance
 
@@ -46,11 +48,15 @@ class TestConnection(unittest.TestCase):
         with self.assertRaises(InterfaceError):
             connection.cursor()
 
-    def test_transaction_management_warnings(self):
+    @mock.patch("warnings.warn")
+    def test_transaction_management_warnings(self, warn_mock):
         connection = self._make_connection()
 
-        with self.assertRaises(Warning):
-            connection.commit()
-
-        with self.assertRaises(Warning):
-            connection.rollback()
+        connection.commit()
+        warn_mock.assert_called_with(
+            AUTOCOMMIT_MODE_WARNING, UserWarning, stacklevel=2
+        )
+        connection.rollback()
+        warn_mock.assert_called_with(
+            AUTOCOMMIT_MODE_WARNING, UserWarning, stacklevel=2
+        )


### PR DESCRIPTION
Add warnings for methods which can't be used in autocommit mode. Update `Connection()` class constructor, and cover it with unit tests.