### PR TITLE
test: run system tests against emulator

### DIFF
--- a/.github/workflows/system-tests-against-emulator.yaml
+++ b/.github/workflows/system-tests-against-emulator.yaml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: Run Spanner integration tests against emulator
+jobs:
+  system-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      emulator:
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        ports:
+          - 9010:9010
+          - 9020:9020
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install nox
+        run: python -m pip install nox
+      - name: Run system tests
+        run: nox -s system-3.7
+        env:
+          SPANNER_EMULATOR_HOST: localhost:9010
+          GOOGLE_CLOUD_PROJECT: emulator-test-project
+          GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE: true

--- a/.github/workflows/system-tests-against-emulator.yaml
+++ b/.github/workflows/system-tests-against-emulator.yaml
@@ -21,11 +21,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install nox
         run: python -m pip install nox
       - name: Run system tests
-        run: nox -s system-3.7
+        run: nox -s system-3.8
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
           GOOGLE_CLOUD_PROJECT: emulator-test-project

--- a/noxfile.py
+++ b/noxfile.py
@@ -94,7 +94,9 @@ def system(session):
     system_test_folder_path = os.path.join("tests", "system")
 
     # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
+    if not os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS", ""
+    ) and not os.environ.get("SPANNER_EMULATOR_HOST", ""):
         session.skip("Credentials must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)


### PR DESCRIPTION
Adding a workflow file to add an ability to run tests against Spanner emulator.
Django tests should be moved into nox system tests, so that we could run them on emulator.