### PR TITLE
fix: Use "any" default role in sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,6 +239,10 @@ html_theme_options = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = "google-cloud-spanner-django-doc"
 
+# Use more convenient default role, affects text in single-backticks
+# https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-anything
+default_role = "any"
+
 # -- Options for warnings ------------------------------------------------------
 
 


### PR DESCRIPTION
So backtick'd text renders as code, links as appropriate.

This is likely to cause some problems, to be merged only with the corresponding changes to the docs.

For https://github.com/googleapis/python-spanner-django/pull/549#discussion_r516241691.