### PR TITLE
chore: Add missing py3.8 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
         "Framework :: Django",
         "Framework :: Django :: 2.2",


### PR DESCRIPTION
We're already testing against 3.8, this PR just adds the version classifier to setup.py.