### PR TITLE
fix: Bump version number after 2.2.1b0 release

### DIFF
--- a/version.py
+++ b/version.py
@@ -4,4 +4,4 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-__version__ = "2.2.1b0"
+__version__ = "2.2.1b1"


### PR DESCRIPTION
Like #571, bump the version number following the [2.2.1b0 release](https://github.com/googleapis/python-spanner-django/releases/tag/v2.2.1b0) to avoid using the same version number in development.