### PR TITLE
fix: Replace, fast-forward Django CI branch

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -44,7 +44,7 @@ export RUNNING_SPANNER_BACKEND_TESTS=1
 
 pip3 install .
 export DJANGO_TESTS_DIR="django_tests_dir"
-mkdir -p $DJANGO_TESTS_DIR && git clone --depth 1 --single-branch --branch spanner-2.2.x https://github.com/timgraham/django.git $DJANGO_TESTS_DIR/django
+mkdir -p $DJANGO_TESTS_DIR && git clone --depth 1 --single-branch --branch "stable/2.2.x" https://github.com/django/django.git $DJANGO_TESTS_DIR/django
 
 # Install dependencies for Django tests.
 sudo apt-get update

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -44,7 +44,7 @@ export RUNNING_SPANNER_BACKEND_TESTS=1
 
 pip3 install .
 export DJANGO_TESTS_DIR="django_tests_dir"
-mkdir -p $DJANGO_TESTS_DIR && git clone --depth 1 --single-branch --branch "stable/2.2.x" https://github.com/django/django.git $DJANGO_TESTS_DIR/django
+mkdir -p $DJANGO_TESTS_DIR && git clone --depth 1 --single-branch --branch "spanner/stable/2.2.x" https://github.com/c24t/django.git $DJANGO_TESTS_DIR/django
 
 # Install dependencies for Django tests.
 sudo apt-get update

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch spanner-2.2.x https://github.com/timgraham/django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "stable/2.2.x" https://github.com/django/django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "stable/2.2.x" https://github.com/django/django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "spanner/stable/2.2.x" https://github.com/c24t/django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.


### PR DESCRIPTION
Addresses #485.

This PR replaces the version of django used in CI tests. It replaces https://github.com/timgraham/django/tree/spanner-2.2.x with https://github.com/c24t/django/tree/spanner/stable/2.2.x. We'll keep this new branch up to date with the [`stable/2.2.x` django branch](https://github.com/django/django/tree/stable/2.2.x).

The new branch has all of @timgraham's django patches, just fast-forwarded to pick up recent changes in `stable/2.2.x`. You can see the full list of those changes with `git rev-list 3ab5235d1d..34010d8ffa`.

For the full list of @timgraham's django patches, see `git rev-list 120fdc3e42..0d551deb67` or [the equivalent diff preview on GH](https://github.com/django/django/compare/stable/2.2.x...timgraham:spanner-2.2.x).
