### PR TITLE
fix: remove error msg check from test_decimal_precision_limit for non emulator test

### DIFF
--- a/tests/system/django_spanner/test_decimal.py
+++ b/tests/system/django_spanner/test_decimal.py
@@ -89,12 +89,10 @@ class TestDecimal(TransactionTestCase):
         """
         num_val = Number(num=Decimal(1) / Decimal(3))
         if USE_EMULATOR:
-            msg = "The NUMERIC type supports 38 digits of precision and 9 digits of scale."
-            with self.assertRaisesRegex(IntegrityError, msg):
+            with self.assertRaises(ValueError):
                 num_val.save()
         else:
-            msg = "400 Invalid value for bind parameter a0: Expected NUMERIC."
-            with self.assertRaisesRegex(ProgrammingError, msg):
+            with self.assertRaisesRegex(ProgrammingError):
                 num_val.save()
 
     def test_decimal_update(self):

--- a/tests/system/django_spanner/test_decimal.py
+++ b/tests/system/django_spanner/test_decimal.py
@@ -91,7 +91,7 @@ class TestDecimal(TransactionTestCase):
             with self.assertRaises(ValueError):
                 num_val.save()
         else:
-            with self.assertRaisesRegex(ProgrammingError):
+            with self.assertRaises(ProgrammingError):
                 num_val.save()
 
     def test_decimal_update(self):

--- a/tests/system/django_spanner/test_decimal.py
+++ b/tests/system/django_spanner/test_decimal.py
@@ -7,7 +7,6 @@
 from .models import Author, Number
 from django.test import TransactionTestCase
 from django.db import connection, ProgrammingError
-from django.db.utils import IntegrityError
 from decimal import Decimal
 from tests.system.django_spanner.utils import (
     setup_instance,


### PR DESCRIPTION
Changed test_decimal_precision_limit to not check specific error msg and only check for exception class in non emulator test case.

Since googleapis/python-spanner#340 python spanner throws ValueError when decimal precision limit is not met. Corrected test case to expect the same exception to be raised.

fixes #645