### PR TITLE
fix: bump version number after 2.2.1b1 release

### DIFF
--- a/django_test_apps.txt
+++ b/django_test_apps.txt
@@ -1,9 +1,6 @@
-admin_filters
 admin_utils
 custom_lookups
 extra_regress
 expressions_case
-model_regress
-modeladmin
 proxy_models
 serializers

--- a/version.py
+++ b/version.py
@@ -4,4 +4,4 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-__version__ = "2.2.1b1"
+__version__ = "2.2.1b2"


### PR DESCRIPTION
Like #596, bump the version number following the 2.2.1b1 release to avoid using the same version number in development.

fixes #661