### PR TITLE
docs: update docs to show decimal field support and check constraints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,23 +283,16 @@ were created.
 Spanner does not support ``ON DELETE CASCADE`` when creating foreign-key
 constraints, so this is not supported in ``django-google-spanner``.
 
-Check constraints aren't supported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``Unsigned`` datatypes are not supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spanner does not support ``CHECK`` constraints so one isn't created for
-`PositiveIntegerField
+Spanner does not support ``Unsigned`` datatypes so `PositiveIntegerField
 <https://docs.djangoproject.com/en/stable/ref/models/fields/#positiveintegerfield>`__
-and `CheckConstraint
-<https://docs.djangoproject.com/en/stable/ref/models/constraints/#checkconstraint>`__
-can't be used.
-
-No native support for ``DecimalField``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Spanner's support for `Decimal <https://www.python.org/dev/peps/pep-0327/>`__
-types is limited to
-`NUMERIC <https://cloud.google.com/spanner/docs/data-types#numeric_types>`__
-precision. Higher-precision values can be stored as strings instead.
+and `PositiveSmallIntegerField
+<https://docs.djangoproject.com/en/3.2/ref/models/fields/#positivesmallintegerfield>`__
+are both stored as `Integer type
+<https://cloud.google.com/spanner/docs/data-types#integer_type>`__
+.
 
 ``Meta.order_with_respect_to`` model option isn't supported
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Update docs to show decimal field support and check constraints but no support for unsigned data type