### PR TITLE
Docs: fix changelog link and sample examples.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,23 +283,16 @@ were created.
 Spanner does not support ``ON DELETE CASCADE`` when creating foreign-key
 constraints, so this is not supported in ``django-google-spanner``.
 
-Check constraints aren't supported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``Unsigned`` datatypes are not supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spanner does not support ``CHECK`` constraints so one isn't created for
-`PositiveIntegerField
+Spanner does not support ``Unsigned`` datatypes so `PositiveIntegerField
 <https://docs.djangoproject.com/en/stable/ref/models/fields/#positiveintegerfield>`__
-and `CheckConstraint
-<https://docs.djangoproject.com/en/stable/ref/models/constraints/#checkconstraint>`__
-can't be used.
-
-No native support for ``DecimalField``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Spanner's support for `Decimal <https://www.python.org/dev/peps/pep-0327/>`__
-types is limited to
-`NUMERIC <https://cloud.google.com/spanner/docs/data-types#numeric_types>`__
-precision. Higher-precision values can be stored as strings instead.
+and `PositiveSmallIntegerField
+<https://docs.djangoproject.com/en/3.2/ref/models/fields/#positivesmallintegerfield>`__
+are both stored as `Integer type
+<https://cloud.google.com/spanner/docs/data-types#integer_type>`__
+.
 
 ``Meta.order_with_respect_to`` model option isn't supported
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/django_spanner/features.py
+++ b/django_spanner/features.py
@@ -38,6 +38,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     skip_tests = (
         # No foreign key constraints in Spanner.
         "backends.tests.FkConstraintsTests.test_check_constraints",
+        # Spanner does not support empty list of DML statement.
+        "backends.tests.BackendTestCase.test_cursor_executemany_with_empty_params_list",
         "fixtures_regress.tests.TestFixtures.test_loaddata_raises_error_when_fixture_has_invalid_foreign_key",
         # No Django transaction management in Spanner.
         "basic.tests.SelectOnSaveTests.test_select_on_save_lying_update",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,1 @@
-# Changelog
+../CHANGELOG.md

--- a/docs/example_from_scratch.md
+++ b/docs/example_from_scratch.md
@@ -1,0 +1,1 @@
+../examples/from-scratch/README.md

--- a/docs/example_healthchecks.md
+++ b/docs/example_healthchecks.md
@@ -1,0 +1,1 @@
+../examples/healthchecks/README.md

--- a/docs/samples.rst
+++ b/docs/samples.rst
@@ -1,24 +1,12 @@
-Sample Code
-####################################
+Sample Examples
+###############
 
-Create and register your first model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To define your database layout create a models file in your app folder and add the relevant 
-classes to it. Spanner works exactly like any other database you may have used with Django. 
-Here is a simple example you can run with Spanner. In our poll application below we create 
-the following two models:
+django-spanner for Django tutorial
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: python
+This `Example <example_from_scratch.html>`_ shows how to use django-spanner for Cloud Spanner as a backend database for `healthchecks.io <https://healthchecks.io>`_ 
 
-    from django.db import models
-    
-    class Question(models.Model):
-        question_text = models.CharField(max_length=200)
-        pub_date = models.DateTimeField('date published')
-        def __str__(self):
-            return str(self.rating)
-    
-    class Choice(models.Model):
-        question = models.ForeignKey(Question, on_delete=models.CASCADE)
-        choice_text = models.CharField(max_length=200)
-        votes = models.IntegerField(default=0)
+django-spanner on healthchecks.io
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This `Example <example_healthchecks.html>`_ shows how to use django-spanner for Cloud Spanner as a backend database for `Django's tutorials <https://docs.djangoproject.com/en/2.2/intro/tutorial01/>`_ 


### PR DESCRIPTION
Docs: fix changelog link and sample examples.

Fix: Skip test `backends.tests.BackendTestCase.test_cursor_executemany_with_empty_params_list` as Spanner does not support empty list of DML statements.