### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,13 @@
 {
-  "name": "django-google-spanner",
-  "name_pretty": "Cloud Spanner Django",
-  "product_documentation": "https://cloud.google.com/spanner/docs/",
-  "client_documentation": "https://googleapis.dev/python/django-google-spanner/latest",
-  "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "INTEGRATION",
-  "repo": "googleapis/python-spanner-django",
-  "distribution_name": "django-google-spanner",
-  "requires_billing": true
+    "name": "django-google-spanner",
+    "name_pretty": "Cloud Spanner Django",
+    "product_documentation": "https://cloud.google.com/spanner/docs/",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/django-google-spanner/latest",
+    "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "INTEGRATION",
+    "repo": "googleapis/python-spanner-django",
+    "distribution_name": "django-google-spanner",
+    "requires_billing": true
 }


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.