### PR TITLE
fix: downgrade google-cloud-spanner to v 3.11.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ description = "Bridge to enable using Django with Spanner."
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["sqlparse >= 0.3.0", "google-cloud-spanner >= 3.11.1"]
+dependencies = ["sqlparse >= 0.3.0", "google-cloud-spanner == 3.11.1"]
 extras = {
     "tracing": [
         "opentelemetry-api >= 1.1.0",


### PR DESCRIPTION
downgrade google-cloud-spanner to v 3.11.1

Temporary fix for : #746 