### PR TITLE
chore: use stable django versions for tests hosted on python-spanner-django

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -9,10 +9,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'cla/google'
     - 'OwlBot Post Processor'
-    - 'system-tests (3.6)'
-    - 'system-tests (3.7)'
-    - 'system-tests (3.8)'
-    - 'system-tests (3.9)'
     - 'system-tests'
     - 'Kokoro'
 permissionRules:

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "spanner/stable/2.2.x" https://github.com/c24t/django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "django/stable/2.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "batch_tests" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "spanner/stable/2.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "django/stable/2.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "batch_tests" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "spanner/stable/2.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
+    git clone --depth 1 --single-branch --branch "django/stable/2.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite_3.2.sh
+++ b/django_test_suite_3.2.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "32_params_num_fix" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
+    git clone --depth 1 --single-branch --branch "spanner/stable/3.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite_3.2.sh
+++ b/django_test_suite_3.2.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "spanner/stable/3.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
+    git clone --depth 1 --single-branch --branch "django/stable/3.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite_3.2.sh
+++ b/django_test_suite_3.2.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "stable/spanner/3.2.x" https://github.com/vi3k6i5/django.git $DJANGO_TESTS_DIR/django3.2
+    git clone --depth 1 --single-branch --branch "django/stable/3.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
 fi
 
 # Install dependencies for Django tests.

--- a/django_test_suite_3.2.sh
+++ b/django_test_suite_3.2.sh
@@ -18,7 +18,7 @@ mkdir -p $DJANGO_TESTS_DIR
 if [ $SPANNER_EMULATOR_HOST != 0 ]
 then
     pip3 install .
-    git clone --depth 1 --single-branch --branch "django/stable/3.2.x" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
+    git clone --depth 1 --single-branch --branch "32_params_num_fix" https://github.com/googleapis/python-spanner-django.git $DJANGO_TESTS_DIR/django3.2
 fi
 
 # Install dependencies for Django tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".[tracing]")
-    session.install("sphinx", "alabaster", "recommonmark", "django==2.2")
+    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "django==2.2")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     # Warnings as errors is disabled for `sphinx-build` because django module
@@ -205,7 +205,7 @@ def docfx(session):
 
     session.install("-e", ".[tracing]")
     session.install(
-        "sphinx",
+        "sphinx==4.0.1",
         "alabaster",
         "recommonmark",
         "gcp-sphinx-docfx-yaml",

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,9 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".[tracing]")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "django==2.2")
+    session.install(
+        "sphinx==4.0.1", "alabaster", "recommonmark", "django==2.2"
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     # Warnings as errors is disabled for `sphinx-build` because django module


### PR DESCRIPTION
chore: use django stable versions for tests hosted on python-spanner-django