### PR TITLE
fix: set batch size for bulk_create() method

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -12,7 +12,10 @@ from itertools import chain
 from django.conf import settings
 from django.core import exceptions
 from django.db import (
-    DJANGO_VERSION_PICKLE_KEY, IntegrityError, connections, router,
+    DJANGO_VERSION_PICKLE_KEY,
+    IntegrityError,
+    connections,
+    router,
     transaction,
 )
 from django.db.models import DateField, DateTimeField, sql
@@ -37,7 +40,9 @@ EmptyResultSet = sql.EmptyResultSet
 
 
 class BaseIterable:
-    def __init__(self, queryset, chunked_fetch=False, chunk_size=GET_ITERATOR_CHUNK_SIZE):
+    def __init__(
+        self, queryset, chunked_fetch=False, chunk_size=GET_ITERATOR_CHUNK_SIZE
+    ):
         self.queryset = queryset
         self.chunked_fetch = chunked_fetch
         self.chunk_size = chunk_size
@@ -155,7 +160,7 @@ class NamedValuesListIterable(ValuesListIterable):
     def create_namedtuple_class(*names):
         # Cache namedtuple() with @lru_cache() since it's too slow to be
         # called for every QuerySet evaluation.
-        return namedtuple('Row', names)
+        return namedtuple("Row", names)
 
     def __iter__(self):
         queryset = self.queryset
@@ -217,7 +222,7 @@ class QuerySet:
         """Don't populate the QuerySet's cache."""
         obj = self.__class__()
         for k, v in self.__dict__.items():
-            if k == '_result_cache':
+            if k == "_result_cache":
                 obj.__dict__[k] = None
             else:
                 obj.__dict__[k] = copy.deepcopy(v, memo)
@@ -461,6 +466,8 @@ class QuerySet:
         connection = connections[self.db]
         fields = self.model._meta.concrete_fields
         objs = list(objs)
+
+        batch_size = 900
         self._populate_pk_values(objs)
         with transaction.atomic(using=self.db, savepoint=False):
             objs_with_pk, objs_without_pk = partition(lambda o: o.pk is None, objs)


### PR DESCRIPTION
Django considers `max_query_params` only for MySQL and Oracle yet. A feature request for Django team to support the attribute for all the backends is created, but for now we can patch our fork to force the attribute value.

Fixes the error:
```python
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/google/api_core/grpc_helpers.py", line 50, in error_remapped_callable
    return callable_(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "Number of parameters in query exceeds the maximum allowed limit of 950."
	debug_error_string = "{"created":"@1656920738.753809851","description":"Error received from peer ipv6:[::1]:9010","file":"src/core/lib/surface/call.cc","file_line":966,"grpc_message":"Number of parameters in query exceeds the maximum allowed limit of 950.","grpc_status":3}"
```