### PR TITLE
fix: override AutoField default value only for Spanner

### DIFF
--- a/django_spanner/__init__.py
+++ b/django_spanner/__init__.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 import pkg_resources
 from google.cloud.spanner_v1 import JsonObject
 from django.db.models.fields import (
+    NOT_PROVIDED,
     AutoField,
     Field,
 )
@@ -61,7 +62,12 @@ def gen_rand_int64():
 def autofield_init(self, *args, **kwargs):
     kwargs["blank"] = True
     Field.__init__(self, *args, **kwargs)
-    self.default = gen_rand_int64
+
+    if (
+        django.db.connection.settings_dict["ENGINE"] == "django_spanner"
+        and self.default == NOT_PROVIDED
+    ):
+        self.default = gen_rand_int64
 
 
 AutoField.__init__ = autofield_init


### PR DESCRIPTION
Fixes #742 