### PR TITLE
chore: update docfx minimum Python version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -201,7 +201,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -207,10 +207,9 @@ def docfx(session):
 
     session.install("-e", ".[tracing]")
     session.install(
-        "sphinx==4.0.1",
+        "gcp-sphinx-docfx-yaml",
         "alabaster",
         "recommonmark",
-        "gcp-sphinx-docfx-yaml",
         "django==2.2",
     )
 


### PR DESCRIPTION
Updates minimum Python version required for DocFX to 3.10. See https://github.com/googleapis/synthtool/pull/1891.

Python3.10 is available by default for Ubuntu22.04, which this repository uses. No installation required.