### PR TITLE
fix: Fixing test_clearsessions_unsupported test

### DIFF
--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -915,9 +915,9 @@ class CookieSessionTests(SessionTestsMixin, SimpleTestCase):
 class ClearSessionsCommandTests(SimpleTestCase):
     def test_clearsessions_unsupported(self):
         msg = (
-            "Session engine 'tests.sessions_tests.no_clear_expired' doesn't "
+            "Session engine 'sessions_tests.no_clear_expired' doesn't "
             "support clearing expired sessions."
         )
-        with self.settings(SESSION_ENGINE='tests.sessions_tests.no_clear_expired'):
+        with self.settings(SESSION_ENGINE='sessions_tests.no_clear_expired'):
             with self.assertRaisesMessage(management.CommandError, msg):
                 management.call_command('clearsessions')


### PR DESCRIPTION
Presubmits are failing for all PRs from last few months for our Django Spanner repo with this error `ModuleNotFoundError: No module named 'tests.sessions_tests'`

The changes were made in Django repo https://github.com/django/django/commit/4c2b26174f044adc4a6461154385720479eaee55 after we forked out from it to our django/stable/3.2.x branch