### PR TITLE
fix: Fixing README.rst to fix release failure.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,8 +151,8 @@ Django version 3.2 and earlier did not support transactions in autocommit mode w
 You can enable transactions in autocommit mode with Spanner with the
 `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` configuration option.
 
- - To enable transactions in autocommit mode in V3.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to True in your settings.py file.
- - To disable transactions in autocommit mode in V4.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to False in your settings.py file.
+- To enable transactions in autocommit mode in V3.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to True in your settings.py file.
+- To disable transactions in autocommit mode in V4.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to False in your settings.py file.
 
 
 Set credentials and project environment variables

--- a/README.rst
+++ b/README.rst
@@ -140,23 +140,23 @@ configured:
            }
        }
 
-  Transaction support in autocommit mode
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Transaction support in autocommit mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Django version 4.2 and higher by default supports transactions in autocommit mode.
-  A transaction is automatically started if you define an
-  [atomic block](https://docs.djangoproject.com/en/4.2/topics/db/transactions/#controlling-transactions-explicitly).
-  
-  Django version 3.2 and earlier did not support transactions in autocommit mode with Spanner.
-  You can enable transactions in autocommit mode with Spanner with the
-  `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` configuration option.
+Django version 4.2 and higher by default supports transactions in autocommit mode.
+A transaction is automatically started if you define an
+[atomic block](https://docs.djangoproject.com/en/4.2/topics/db/transactions/#controlling-transactions-explicitly).
 
-  - To enable transactions in autocommit mode in V3.2, set
-  the flag "ALLOW_TRANSACTIONS_IN_AUTO_COMMIT" to True in your
-  settings.py file.
-  - To disable transactions in autocommit mode in V4.2, set
-  the flag "ALLOW_TRANSACTIONS_IN_AUTO_COMMIT" to False in your
-  settings.py file.
+Django version 3.2 and earlier did not support transactions in autocommit mode with Spanner.
+You can enable transactions in autocommit mode with Spanner with the
+`ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` configuration option.
+
+ - To enable transactions in autocommit mode in V3.2, set
+the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to True in your
+settings.py file.
+ - To disable transactions in autocommit mode in V4.2, set
+the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to False in your
+settings.py file.
 
 
 Set credentials and project environment variables

--- a/README.rst
+++ b/README.rst
@@ -151,12 +151,8 @@ Django version 3.2 and earlier did not support transactions in autocommit mode w
 You can enable transactions in autocommit mode with Spanner with the
 `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` configuration option.
 
- - To enable transactions in autocommit mode in V3.2, set
-the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to True in your
-settings.py file.
- - To disable transactions in autocommit mode in V4.2, set
-the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to False in your
-settings.py file.
+ - To enable transactions in autocommit mode in V3.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to True in your settings.py file.
+ - To disable transactions in autocommit mode in V4.2, set the flag `ALLOW_TRANSACTIONS_IN_AUTO_COMMIT` to False in your settings.py file.
 
 
 Set credentials and project environment variables


### PR DESCRIPTION
More details here https://github.com/googleapis/python-spanner-django/issues/883

Please see the README section before and after this PR changes -
Before this PR : https://github.com/googleapis/python-spanner-django/tree/main?tab=readme-ov-file#transaction-support-in-autocommit-mode

After this PR : https://github.com/googleapis/python-spanner-django/tree/readme_fix?tab=readme-ov-file#transaction-support-in-autocommit-mode