### PR TITLE
fix: mockserver_tests

### DIFF
--- a/tests/mockserver_tests/test_basics.py
+++ b/tests/mockserver_tests/test_basics.py
@@ -15,6 +15,7 @@ from google.cloud.spanner_v1 import (
     BatchCreateSessionsRequest,
     ExecuteSqlRequest,
     CommitRequest,
+    CreateSessionRequest,
 )
 from tests.mockserver_tests.mock_server_test_base import (
     MockServerTestBase,
@@ -36,9 +37,10 @@ class TestBasics(MockServerTestBase):
             self.assertEqual(row[0], 1)
         self.assertEqual(len(result_list), 1)
         requests = self.spanner_service.requests
-        self.assertEqual(len(requests), 2)
+        self.assertEqual(len(requests), 3)
         self.assertIsInstance(requests[0], BatchCreateSessionsRequest)
-        self.assertIsInstance(requests[1], ExecuteSqlRequest)
+        self.assertIsInstance(requests[1], CreateSessionRequest)
+        self.assertIsInstance(requests[2], ExecuteSqlRequest)
 
     def test_select1(self):
         add_select1_result()
@@ -59,9 +61,10 @@ class TestBasics(MockServerTestBase):
         singers = Singer.objects.all()
         self.assertEqual(len(singers), 2)
         requests = self.spanner_service.requests
-        self.assertEqual(len(requests), 2)
+        self.assertEqual(len(requests), 3)
         self.assertIsInstance(requests[0], BatchCreateSessionsRequest)
-        self.assertIsInstance(requests[1], ExecuteSqlRequest)
+        self.assertIsInstance(requests[1], CreateSessionRequest)
+        self.assertIsInstance(requests[2], ExecuteSqlRequest)
 
     def test_django_select_singer_using_other_db(self):
         add_singer_query_result(
@@ -70,9 +73,10 @@ class TestBasics(MockServerTestBase):
         singers = Singer.objects.using("secondary").all()
         self.assertEqual(len(singers), 2)
         requests = self.spanner_service.requests
-        self.assertEqual(len(requests), 2)
+        self.assertEqual(len(requests), 3)
         self.assertIsInstance(requests[0], BatchCreateSessionsRequest)
-        self.assertIsInstance(requests[1], ExecuteSqlRequest)
+        self.assertIsInstance(requests[1], CreateSessionRequest)
+        self.assertIsInstance(requests[2], ExecuteSqlRequest)
 
     def test_insert_singer(self):
         add_update_count(
@@ -84,15 +88,16 @@ class TestBasics(MockServerTestBase):
         singer = Singer(first_name="test", last_name="test")
         singer.save()
         requests = self.spanner_service.requests
-        self.assertEqual(len(requests), 3)
+        self.assertEqual(len(requests), 4)
         self.assertIsInstance(requests[0], BatchCreateSessionsRequest)
-        self.assertIsInstance(requests[1], ExecuteSqlRequest)
-        self.assertIsInstance(requests[2], CommitRequest)
+        self.assertIsInstance(requests[1], CreateSessionRequest)
+        self.assertIsInstance(requests[2], ExecuteSqlRequest)
+        self.assertIsInstance(requests[3], CommitRequest)
         # The ExecuteSqlRequest should have 3 parameters:
         # 1. first_name
         # 2. last_name
         # 3. client-side auto-generated primary key
-        self.assertEqual(len(requests[1].params), 3)
+        self.assertEqual(len(requests[2].params), 3)
 
     def test_insert_singer_with_disabled_random_primary_key(self):
         for db, config in DATABASES.items():
@@ -115,15 +120,16 @@ class TestBasics(MockServerTestBase):
             singer = LocalSinger(first_name="test", last_name="test")
             singer.save()
             requests = self.spanner_service.requests
-            self.assertEqual(len(requests), 3)
+            self.assertEqual(len(requests), 4)
             self.assertIsInstance(requests[0], BatchCreateSessionsRequest)
-            self.assertIsInstance(requests[1], ExecuteSqlRequest)
-            self.assertIsInstance(requests[2], CommitRequest)
+            self.assertIsInstance(requests[1], CreateSessionRequest)
+            self.assertIsInstance(requests[2], ExecuteSqlRequest)
+            self.assertIsInstance(requests[3], CommitRequest)
             # The ExecuteSqlRequest should have 2 parameters:
             # 1. first_name
             # 2. last_name
             # There should be no client-side auto-generated primary key.
-            self.assertEqual(len(requests[1].params), 2)
+            self.assertEqual(len(requests[2].params), 2)
         finally:
             for db, config in DATABASES.items():
                 if config["ENGINE"] == "django_spanner":


### PR DESCRIPTION
Hello, Thank you for maintaining this library. Please let me try to contribute. (Sorry for creating noisy 2 PRs)
I have realized "mockserver_tests" failed with current main branch with Github Actions.

I assuming this fails came from outside library change and just fix Test code to pass it.
please correct me if this require actual code need to be changed

Here is update summary

---
This pull request updates several unit tests in `test_basics.py` to account for the introduction of a new `CreateSessionRequest` in the request sequence when interacting with the mock Spanner service. The main change is that each tested operation now expects an additional session creation request, and the assertions have been updated accordingly. This ensures that the tests accurately reflect the current behavior of the service.

**Test assertion updates for session creation:**

* Added `CreateSessionRequest` to the imports and updated all relevant test assertions to expect an additional request in the sequence (`BatchCreateSessionsRequest`, `CreateSessionRequest`, then `ExecuteSqlRequest` or `CommitRequest`).
* Modified assertions in `verify_select1`, `test_django_select_singer`, and `test_django_select_singer_using_other_db` to expect three requests, with the second being a `CreateSessionRequest` instead of directly an `ExecuteSqlRequest`. [[1]](diffhunk://#diff-5beaa2c22d87c60d32ddcc64a1bf91c9248b17c264eba035178f9a12c3bf2da6L39-R43) [[2]](diffhunk://#diff-5beaa2c22d87c60d32ddcc64a1bf91c9248b17c264eba035178f9a12c3bf2da6L62-R67) [[3]](diffhunk://#diff-5beaa2c22d87c60d32ddcc64a1bf91c9248b17c264eba035178f9a12c3bf2da6L73-R79)
* Updated `test_insert_singer` and the `LocalSinger` model test to expect four requests (including `CreateSessionRequest`), and adjusted parameter count checks to reference the correct request index. [[1]](diffhunk://#diff-5beaa2c22d87c60d32ddcc64a1bf91c9248b17c264eba035178f9a12c3bf2da6L87-R100) [[2]](diffhunk://#diff-5beaa2c22d87c60d32ddcc64a1bf91c9248b17c264eba035178f9a12c3bf2da6L118-R132)
* 

---
